### PR TITLE
.gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# IntelliJ
+*.iml


### PR DESCRIPTION
This PR:

- is primarily intended to test the new repo workflow
- it adds *.iml files to .gitignore, mirroring the sister talentcatalog repository