### PR TITLE
rest api reader for candidate batch processing

### DIFF
--- a/src/main/java/org/tctalent/anonymization/batch/BatchConfig.java
+++ b/src/main/java/org/tctalent/anonymization/batch/BatchConfig.java
@@ -91,7 +91,7 @@ public class BatchConfig {
       LoggingItemProcessListener loggingItemProcessListener,
       LoggingItemWriterListener loggingItemWriterListener) {
 
-    return new StepBuilder("candidateMigrationStep", jobRepository)
+    return new StepBuilder("candidateJpaMigrationStep", jobRepository)
         .<Candidate, CandidateDocument>chunk(batchProperties.getChunkSize(), transactionManager)
         .reader(jpaItemReader)
         .processor(itemProcessor)
@@ -133,7 +133,7 @@ public class BatchConfig {
       LoggingItemProcessListener loggingItemProcessListener,
       LoggingItemWriterListener loggingItemWriterListener) {
 
-    return new StepBuilder("candidateMigrationStep", jobRepository)
+    return new StepBuilder("candidateRestMigrationStep", jobRepository)
         .<IdentifiableCandidate, CandidateDocument>chunk(batchProperties.getChunkSize(), transactionManager)
         .reader(tcItemReader)
         .processor(itemProcessor)

--- a/src/main/java/org/tctalent/anonymization/batch/BatchConfig.java
+++ b/src/main/java/org/tctalent/anonymization/batch/BatchConfig.java
@@ -13,13 +13,14 @@ import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
 import org.springframework.batch.item.data.builder.RepositoryItemWriterBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.tctalent.anonymization.entity.db.Candidate;
 import org.tctalent.anonymization.entity.mongo.CandidateDocument;
-import org.tctalent.anonymization.mapper.CandidateMapper;
+import org.tctalent.anonymization.model.IdentifiableCandidate;
 import org.tctalent.anonymization.repository.CandidateMongoRepository;
 import org.tctalent.anonymization.repository.CandidateRepository;
 
@@ -30,10 +31,10 @@ import org.tctalent.anonymization.repository.CandidateRepository;
  * This class defines the Spring Batch beans required for the candidate migration process:
  * - A job to encapsulate the overall batch process
  * - A step to read, process, and write candidates
- * - Components for reading from a JPA repository, processing entities into documents,
- *   and writing documents to MongoDB
+ * - Components for reading from the TC service or JPA repository, processing candidates into
+ *   anonymised documents, and writing documents to MongoDB
  * </p>
- * Additional logging listeners are included to monitor and log the batch progress at various
+ * Additional logging listeners are configured to monitor and log the batch progress at various
  * stages.
  *
  * @author sadatmalik
@@ -53,7 +54,8 @@ public class BatchConfig {
    * @return the configured candidate migration job
    */
   @Bean
-  public Job candidateMigrationJob(JobRepository jobRepository, Step candidateMigrationStep,
+  public Job candidateMigrationJob(JobRepository jobRepository,
+      @Qualifier("candidateRestMigrationStep") Step candidateMigrationStep,
       JobCompletionNotificationListener listener) {
 
     return new JobBuilder("candidateMigrationJob", jobRepository)
@@ -63,8 +65,8 @@ public class BatchConfig {
   }
 
   /**
-   * Configures the candidate migration step to read candidates, process them, and write them to
-   * MongoDB.
+   * Configures a candidate migration step to read candidates from JPA, process them to anonymised
+   * equivalent documents, and write them to MongoDB.
    *
    * @param jobRepository the repository for storing step metadata
    * @param transactionManager the transaction manager for the step
@@ -78,7 +80,8 @@ public class BatchConfig {
    * @return the configured candidate migration step
    */
   @Bean
-  public Step candidateMigrationStep(JobRepository jobRepository,
+  @Qualifier("candidateJpaMigrationStep")
+  public Step candidateJpaMigrationStep(JobRepository jobRepository,
       DataSourceTransactionManager transactionManager,
       ItemReader<Candidate> jpaItemReader,
       ItemProcessor<Candidate, CandidateDocument> itemProcessor,
@@ -103,6 +106,48 @@ public class BatchConfig {
   }
 
   /**
+   * Configures a candidate migration step to read candidates from the
+   * {@link org.tctalent.anonymization.service.TalentCatalogService}, process them to anonymised
+   * equivalent documents, and write them to MongoDB.
+   *
+   * @param jobRepository the repository for storing step metadata
+   * @param transactionManager the transaction manager for the step
+   * @param tcItemReader the reader to fetch candidates from the talent catalog service
+   * @param itemProcessor the processor to transform candidates into candidate documents
+   * @param mongoItemWriter the writer to save candidate documents to MongoDB
+   * @param loggingChunkListener the listener for chunk-level logging
+   * @param loggingItemReaderListener the listener for item read-level logging
+   * @param loggingItemProcessListener the listener for item process-level logging
+   * @param loggingItemWriterListener the listener for item write-level logging
+   * @return the configured candidate migration step
+   */
+  @Bean
+  @Qualifier("candidateRestMigrationStep")
+  public Step candidateRestMigrationStep(JobRepository jobRepository,
+      DataSourceTransactionManager transactionManager,
+      ItemReader<IdentifiableCandidate> tcItemReader,
+      ItemProcessor<IdentifiableCandidate, CandidateDocument> itemProcessor,
+      ItemWriter<CandidateDocument> mongoItemWriter,
+      LoggingChunkListener loggingChunkListener,
+      LoggingItemReaderListener loggingItemReaderListener,
+      LoggingItemProcessListener loggingItemProcessListener,
+      LoggingItemWriterListener loggingItemWriterListener) {
+
+    return new StepBuilder("candidateMigrationStep", jobRepository)
+        .<IdentifiableCandidate, CandidateDocument>chunk(batchProperties.getChunkSize(), transactionManager)
+        .reader(tcItemReader)
+        .processor(itemProcessor)
+        .writer(mongoItemWriter)
+        .listener(loggingChunkListener)
+        .listener(loggingItemReaderListener)
+        .listener(loggingItemProcessListener)
+        .listener(loggingItemWriterListener)
+        .faultTolerant()
+        .skipPolicy(new ConditionalSkipPolicy(100)) // todo - sm - make configurable
+        .build();
+  }
+
+  /**
    * Configures an ItemReader to fetch paginated candidates from the JPA repository.
    *
    * @param candidateRepository the repository used to retrieve candidates
@@ -118,18 +163,6 @@ public class BatchConfig {
         .arguments(Collections.emptyList())
         .sorts(Collections.singletonMap("id", Sort.Direction.ASC))
         .build();
-  }
-
-  /**
-   * Configures the CandidateItemProcessor with a mapper to transform Candidate entities into
-   * CandidateDocument objects.
-   *
-   * @param mapper the mapper used for converting Candidate entities to CandidateDocument objects
-   * @return the configured CandidateItemProcessor
-   */
-  @Bean
-  public CandidateItemProcessor processor(CandidateMapper mapper) {
-    return new CandidateItemProcessor(mapper);
   }
 
   /**

--- a/src/main/java/org/tctalent/anonymization/batch/BatchConfig.java
+++ b/src/main/java/org/tctalent/anonymization/batch/BatchConfig.java
@@ -143,7 +143,7 @@ public class BatchConfig {
         .listener(loggingItemProcessListener)
         .listener(loggingItemWriterListener)
         .faultTolerant()
-        .skipPolicy(new ConditionalSkipPolicy(100)) // todo - sm - make configurable
+        .skipPolicy(new ConditionalSkipPolicy(batchProperties.getMaxReadSkips()))
         .build();
   }
 

--- a/src/main/java/org/tctalent/anonymization/batch/BatchProperties.java
+++ b/src/main/java/org/tctalent/anonymization/batch/BatchProperties.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Component;
  *  batch:
  *    chunk-size: 100
  *    page-size: 100
+ *    max-read-skips: 3
+ *    fetch-delay-millis: 1000
  * </pre>
  *
  * @author sadatmalik

--- a/src/main/java/org/tctalent/anonymization/batch/BatchProperties.java
+++ b/src/main/java/org/tctalent/anonymization/batch/BatchProperties.java
@@ -24,4 +24,6 @@ import org.springframework.stereotype.Component;
 public class BatchProperties {
   private int chunkSize;
   private int pageSize;
+  private int maxReadSkips;
+  private int fetchDelayMillis;
 }

--- a/src/main/java/org/tctalent/anonymization/batch/BatchProperties.java
+++ b/src/main/java/org/tctalent/anonymization/batch/BatchProperties.java
@@ -27,5 +27,5 @@ public class BatchProperties {
   private int chunkSize;
   private int pageSize;
   private int maxReadSkips;
-  private int fetchDelayMillis;
+  private long fetchDelayMillis;
 }

--- a/src/main/java/org/tctalent/anonymization/batch/CandidateItemProcessor.java
+++ b/src/main/java/org/tctalent/anonymization/batch/CandidateItemProcessor.java
@@ -26,7 +26,7 @@ public class CandidateItemProcessor implements
 
   @Override
   public CandidateDocument process(@NonNull final Candidate entity) {
-    return candidateMapper.toDocument(entity);
+    return candidateMapper.anonymize(entity);
   }
 
 }

--- a/src/main/java/org/tctalent/anonymization/batch/CandidateJpaItemProcessor.java
+++ b/src/main/java/org/tctalent/anonymization/batch/CandidateJpaItemProcessor.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
 import org.tctalent.anonymization.entity.db.Candidate;
 import org.tctalent.anonymization.entity.mongo.CandidateDocument;
 import org.tctalent.anonymization.mapper.CandidateMapper;
@@ -19,8 +20,8 @@ import org.tctalent.anonymization.mapper.CandidateMapper;
  */
 @Slf4j
 @RequiredArgsConstructor
-public class CandidateItemProcessor implements
-    ItemProcessor<Candidate, CandidateDocument> {
+@Component
+public class CandidateJpaItemProcessor implements ItemProcessor<Candidate, CandidateDocument> {
 
   private final CandidateMapper candidateMapper;
 

--- a/src/main/java/org/tctalent/anonymization/batch/CandidateRestItemProcessor.java
+++ b/src/main/java/org/tctalent/anonymization/batch/CandidateRestItemProcessor.java
@@ -1,0 +1,35 @@
+package org.tctalent.anonymization.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.tctalent.anonymization.entity.mongo.CandidateDocument;
+import org.tctalent.anonymization.mapper.CandidateMapper;
+import org.tctalent.anonymization.model.IdentifiableCandidate;
+
+
+/**
+ * Processor that implements the {@link ItemProcessor} interface to map
+ * {@link IdentifiableCandidate} models into {@link CandidateDocument} objects. The mapping is
+ * delegated to the {@link CandidateMapper}.
+ * </p>
+ * Used as part of the candidate migration batch process.
+ *
+ * @author sadatmalik
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CandidateRestItemProcessor implements
+    ItemProcessor<IdentifiableCandidate, CandidateDocument> {
+
+  private final CandidateMapper candidateMapper;
+
+  @Override
+  public CandidateDocument process(@NonNull final IdentifiableCandidate model) {
+    return candidateMapper.anonymize(model);
+  }
+
+}

--- a/src/main/java/org/tctalent/anonymization/batch/ConditionalSkipPolicy.java
+++ b/src/main/java/org/tctalent/anonymization/batch/ConditionalSkipPolicy.java
@@ -1,0 +1,52 @@
+package org.tctalent.anonymization.batch;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.step.skip.SkipPolicy;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.tctalent.anonymization.exception.RestApiReaderException;
+import org.tctalent.anonymization.logging.LogBuilder;
+
+/**
+ * Skip policy that implements the {@link SkipPolicy} interface to control the number of skips
+ * allowed for {@link RestApiReaderException} exceptions.
+ * </p>
+ * If there are a significantly large number of read errors from the REST API, the job configured
+ * with this policy will fail. This is to prevent the job from running indefinitely if the REST API
+ * is not responding as expected.
+ * </p>
+ * Used as part of the candidate migration batch process.
+ *
+ * @author sadatmalik
+ */
+@Slf4j
+public class ConditionalSkipPolicy implements SkipPolicy {
+
+  private final AtomicInteger restApiReaderExceptionCount = new AtomicInteger(0);
+  private final int maxRestApiReaderSkips;
+
+  public ConditionalSkipPolicy(int maxRestApiReaderSkips) {
+    this.maxRestApiReaderSkips = maxRestApiReaderSkips;
+  }
+
+  @Override
+  public boolean shouldSkip(Throwable t, long skipCount) {
+    // Always skip for non-RestApiReaderException
+    if (!(t instanceof RestApiReaderException)) {
+      return true;
+    }
+
+    // For RestApiReaderException, count skips and fail if limit exceeded
+    int currentCount = restApiReaderExceptionCount.incrementAndGet();
+
+    if (currentCount >= maxRestApiReaderSkips) {
+      LogBuilder.builder(log)
+          .action("Skip policy")
+          .message("Max skip limit for RestApiReaderException reached: " +  currentCount + " skips")
+          .logError();
+
+      return false; // Do not skip, fail the job
+    }
+
+    return true; // Skip within the limit
+  }
+}

--- a/src/main/java/org/tctalent/anonymization/batch/ConditionalSkipPolicy.java
+++ b/src/main/java/org/tctalent/anonymization/batch/ConditionalSkipPolicy.java
@@ -38,7 +38,7 @@ public class ConditionalSkipPolicy implements SkipPolicy {
     // For RestApiReaderException, count skips and fail if limit exceeded
     int currentCount = restApiReaderExceptionCount.incrementAndGet();
 
-    if (currentCount >= maxRestApiReaderSkips) {
+    if (currentCount > maxRestApiReaderSkips) {
       LogBuilder.builder(log)
           .action("Skip policy")
           .message("Max skip limit for RestApiReaderException reached: " +  currentCount + " skips")

--- a/src/main/java/org/tctalent/anonymization/batch/LoggingItemReaderListener.java
+++ b/src/main/java/org/tctalent/anonymization/batch/LoggingItemReaderListener.java
@@ -3,24 +3,24 @@ package org.tctalent.anonymization.batch;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.ItemReadListener;
 import org.springframework.stereotype.Component;
-import org.tctalent.anonymization.entity.db.Candidate;
 import org.tctalent.anonymization.logging.LogBuilder;
+import org.tctalent.anonymization.model.IdentifiableCandidate;
 
 /**
  * Listener that implements {@link ItemReadListener} to provide logging for errors that
- * occur while reading individual items.
+ * occur while reading individual {@link IdentifiableCandidate} items.
  *
  * @author sadatmalik
  */
 @Slf4j
 @Component
-public class LoggingItemReaderListener implements ItemReadListener<Candidate> {
+public class LoggingItemReaderListener implements ItemReadListener<IdentifiableCandidate> {
 
   @Override
   public void onReadError(Exception exception) {
     LogBuilder.builder(log)
-        .action("Error reading item")
-        .message("Error message:" + exception.getMessage())
+        .action("Error reading item from TC service")
+        .message("Error message: " + exception.getMessage())
         .logError(exception);
   }
 

--- a/src/main/java/org/tctalent/anonymization/batch/RestApiItemReader.java
+++ b/src/main/java/org/tctalent/anonymization/batch/RestApiItemReader.java
@@ -25,6 +25,7 @@ import org.tctalent.anonymization.service.TalentCatalogService;
 @Qualifier("restApiItemReader")
 public class RestApiItemReader implements ItemReader<IdentifiableCandidate> {
 
+  private final BatchProperties batchProperties;
   private final TalentCatalogService talentCatalogService;
 
   private int currentPage = 0;
@@ -35,6 +36,7 @@ public class RestApiItemReader implements ItemReader<IdentifiableCandidate> {
   private long lastFetchTime = 0;
 
   public RestApiItemReader(TalentCatalogService talentCatalogService, BatchProperties batchProperties) {
+    this.batchProperties = batchProperties;
     this.talentCatalogService = talentCatalogService;
     this.fetchDelayMillis = batchProperties.getFetchDelayMillis();
   }
@@ -61,7 +63,8 @@ public class RestApiItemReader implements ItemReader<IdentifiableCandidate> {
       applyRateLimiting();
 
       // Fetch next batch
-      IdentifiableCandidatePage page = talentCatalogService.fetchPageOfIdentifiableCandidateData(currentPage);
+      IdentifiableCandidatePage page = talentCatalogService
+          .fetchPageOfIdentifiableCandidateData(currentPage, batchProperties.getPageSize());
 
       if (page == null || page.getContent() == null) {
         throw new RestApiReaderException("Received null or invalid response from the REST API");

--- a/src/main/java/org/tctalent/anonymization/batch/RestApiItemReader.java
+++ b/src/main/java/org/tctalent/anonymization/batch/RestApiItemReader.java
@@ -1,0 +1,62 @@
+package org.tctalent.anonymization.batch;
+
+import java.util.Iterator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.tctalent.anonymization.exception.RestApiReaderException;
+import org.tctalent.anonymization.model.IdentifiableCandidate;
+import org.tctalent.anonymization.model.IdentifiableCandidatePage;
+import org.tctalent.anonymization.service.TalentCatalogService;
+
+/**
+ * An {@link ItemReader} implementation that reads data from the {@link TalentCatalogService},
+ * fetching paginated batches of {@link IdentifiableCandidate} objects.
+ *
+ * @author sadatmalik
+ */
+@Component
+@RequiredArgsConstructor
+@Qualifier("restApiItemReader")
+public class RestApiItemReader implements ItemReader<IdentifiableCandidate> {
+
+  private final TalentCatalogService talentCatalogService;
+
+  private int currentPage = 0;
+  private int totalPages = 1; // Initialise with 1 to start fetching
+  private Iterator<IdentifiableCandidate> batchIterator;
+
+  @Override
+  public IdentifiableCandidate read() throws RestApiReaderException {
+    try {
+      if (batchIterator == null || !batchIterator.hasNext()) {
+        fetchNextBatch();
+      }
+      return batchIterator != null && batchIterator.hasNext() ? batchIterator.next() : null;
+    } catch (RestApiReaderException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RestApiReaderException("Failed to read IdentifiableCandidate from REST API", e);
+    }
+  }
+
+  private void fetchNextBatch() {
+    if (!talentCatalogService.isLoggedIn()) {
+      talentCatalogService.login();
+    }
+    if (currentPage < totalPages) {
+      IdentifiableCandidatePage page = talentCatalogService.fetchPageOfIdentifiableCandidateData(currentPage);
+
+      if (page == null || page.getContent() == null) {
+        throw new RestApiReaderException("Received null or invalid response from the REST API");
+      }
+
+      List<IdentifiableCandidate> currentBatch = page.getContent();
+      totalPages = page.getTotalPages();
+      batchIterator = currentBatch.iterator();
+      currentPage++;
+    }
+  }
+}

--- a/src/main/java/org/tctalent/anonymization/batch/RestApiItemReader.java
+++ b/src/main/java/org/tctalent/anonymization/batch/RestApiItemReader.java
@@ -2,7 +2,6 @@ package org.tctalent.anonymization.batch;
 
 import java.util.Iterator;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/src/main/java/org/tctalent/anonymization/batch/RestApiItemReader.java
+++ b/src/main/java/org/tctalent/anonymization/batch/RestApiItemReader.java
@@ -3,6 +3,7 @@ package org.tctalent.anonymization.batch;
 import java.util.Iterator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -14,9 +15,12 @@ import org.tctalent.anonymization.service.TalentCatalogService;
 /**
  * An {@link ItemReader} implementation that reads data from the {@link TalentCatalogService},
  * fetching paginated batches of {@link IdentifiableCandidate} objects.
+ * </p>
+ * Rate limiting is applied to avoid hitting the API too frequently.
  *
  * @author sadatmalik
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 @Qualifier("restApiItemReader")
@@ -27,6 +31,9 @@ public class RestApiItemReader implements ItemReader<IdentifiableCandidate> {
   private int currentPage = 0;
   private int totalPages = 1; // Initialise with 1 to start fetching
   private Iterator<IdentifiableCandidate> batchIterator;
+
+  private final long fetchDelayMillis = 1000; // 1 second delay todo - sm - make configurable
+  private long lastFetchTime = 0;
 
   @Override
   public IdentifiableCandidate read() throws RestApiReaderException {
@@ -47,6 +54,9 @@ public class RestApiItemReader implements ItemReader<IdentifiableCandidate> {
       talentCatalogService.login();
     }
     if (currentPage < totalPages) {
+      applyRateLimiting();
+
+      // Fetch next batch
       IdentifiableCandidatePage page = talentCatalogService.fetchPageOfIdentifiableCandidateData(currentPage);
 
       if (page == null || page.getContent() == null) {
@@ -57,6 +67,25 @@ public class RestApiItemReader implements ItemReader<IdentifiableCandidate> {
       totalPages = page.getTotalPages();
       batchIterator = currentBatch.iterator();
       currentPage++;
+
+      lastFetchTime = System.currentTimeMillis(); // Update fetch timestamp
+    }
+  }
+
+  private void applyRateLimiting() {
+    long now = System.currentTimeMillis();
+    long timeSinceLastFetch = now - lastFetchTime;
+
+    if (timeSinceLastFetch < fetchDelayMillis) {
+      long remainingDelay = fetchDelayMillis - timeSinceLastFetch;
+
+      try {
+        log.debug("Sleeping for {} ms to avoid hitting the API too frequently", remainingDelay);
+        Thread.sleep(remainingDelay); // Sleep remaining time
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RestApiReaderException("Fetch was interrupted during rate limiting", e);
+      }
     }
   }
 }

--- a/src/main/java/org/tctalent/anonymization/batch/RestApiItemReader.java
+++ b/src/main/java/org/tctalent/anonymization/batch/RestApiItemReader.java
@@ -22,7 +22,6 @@ import org.tctalent.anonymization.service.TalentCatalogService;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @Qualifier("restApiItemReader")
 public class RestApiItemReader implements ItemReader<IdentifiableCandidate> {
 
@@ -32,8 +31,13 @@ public class RestApiItemReader implements ItemReader<IdentifiableCandidate> {
   private int totalPages = 1; // Initialise with 1 to start fetching
   private Iterator<IdentifiableCandidate> batchIterator;
 
-  private final long fetchDelayMillis = 1000; // 1 second delay todo - sm - make configurable
+  private final long fetchDelayMillis;
   private long lastFetchTime = 0;
+
+  public RestApiItemReader(TalentCatalogService talentCatalogService, BatchProperties batchProperties) {
+    this.talentCatalogService = talentCatalogService;
+    this.fetchDelayMillis = batchProperties.getFetchDelayMillis();
+  }
 
   @Override
   public IdentifiableCandidate read() throws RestApiReaderException {

--- a/src/main/java/org/tctalent/anonymization/config/properties/TalentCatalogServiceProperties.java
+++ b/src/main/java/org/tctalent/anonymization/config/properties/TalentCatalogServiceProperties.java
@@ -1,0 +1,31 @@
+package org.tctalent.anonymization.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration properties for {@link org.tctalent.anonymization.service.TalentCatalogService}.
+ * </p>
+ * Example configuration in {@code application.yml}:
+ * <pre>
+ *  tc-service:
+ *    api-url: http://localhost:8080/api/admin
+ *    search-id: 4672
+ *    username: appAnonDatabaseService
+ *    password: 12345678
+ * </pre>
+ *
+ * @author sadatmalik
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "tc-service")
+public class TalentCatalogServiceProperties {
+  private String apiUrl;
+  private long searchId;
+  private String username;
+  private String password;
+}

--- a/src/main/java/org/tctalent/anonymization/entity/mongo/IdentifiableCandidate.java
+++ b/src/main/java/org/tctalent/anonymization/entity/mongo/IdentifiableCandidate.java
@@ -7,8 +7,8 @@ import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.tctalent.anonymization.entity.common.enums.AvailImmediateReason;
 import org.tctalent.anonymization.entity.common.enums.CandidateStatus;
 import org.tctalent.anonymization.entity.common.enums.DocumentStatus;
 import org.tctalent.anonymization.entity.common.enums.Gender;
@@ -24,16 +24,11 @@ import org.tctalent.anonymization.entity.common.enums.WorkPermit;
 import org.tctalent.anonymization.entity.common.enums.YesNo;
 import org.tctalent.anonymization.entity.common.enums.YesNoUnemployedOther;
 import org.tctalent.anonymization.entity.common.enums.YesNoUnsure;
-import org.tctalent.anonymization.entity.common.enums.AvailImmediateReason;
 
 @Getter
 @Setter
-@Document(collection = "candidates")
-public class CandidateDocument {
-
-  private UUID uuid;
-
-  private String candidateNumber;
+public class IdentifiableCandidate {
+  private String id;
   private String additionalInfo;
 
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
@@ -72,8 +67,6 @@ public class CandidateDocument {
 
   @Valid
   private List<@Valid CandidateLanguage> candidateLanguages;
-
-  // todo sm tested up to here - remove this comment after writing unit tests - placeholder
   private String candidateMessage;
 
   @Valid
@@ -83,13 +76,14 @@ public class CandidateDocument {
   private List<@Valid CandidateOccupation> candidateOccupations;
 
   @Valid
-  private List<@Valid ModelList> candidateSavedLists;
+  private List<@Valid Object> candidateSavedLists;
 
   @Valid
   private List<@Valid CandidateSkill> candidateSkills;
 
   @Valid
   private List<@Valid CandidateVisaCheck> candidateVisaChecks;
+
   private YesNo canDrive;
   private String city;
   private YesNo conflict;
@@ -135,7 +129,7 @@ public class CandidateDocument {
   private Float ieltsScore;
 
   @Valid
-  private List<IntRecruitReason> intRecruitReasons;
+  private List<IntRecruitReason> intRecruitReasons ;
   private String intRecruitOther;
   private YesNoUnsure intRecruitRural;
   private String intRecruitRuralNotes;
@@ -157,6 +151,7 @@ public class CandidateDocument {
 
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
   private LocalDate militaryEnd;
+
   private String militaryNotes;
   private User miniIntakeCompletedBy;
 
@@ -227,37 +222,51 @@ public class CandidateDocument {
 
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
   private Instant updatedDate;
+  private String candidateNumber;
 
-  @Override
-  public int hashCode() {
-    if (uuid != null) {
-      return uuid.hashCode();
-    } else {
-      return super.hashCode();
-    }
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-
-    if (obj == null || getClass() != obj.getClass()) {
-      return false;
-    }
-    CandidateDocument other = (CandidateDocument) obj;
-
-    //If id is missing assume that it is not equal to other instance.
-    if (uuid == null) return false;
-
-    //Equivalence by id
-    return uuid.equals(other.uuid);
-  }
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+  private LocalDate dob;
+  private String externalId;
+  private String externalIdSource;
+  private String linkedInLink;
+  private String phone;
+  private String address1;
+  private String regoIp;
+  private String regoPartnerParam;
+  private String regoReferrerParam;
+  private String regoUtmCampaign;
+  private String regoUtmContent;
+  private String regoUtmMedium;
+  private String regoUtmSource;
+  private String regoUtmTerm;
+  private User user;
+  private String unhcrFile;
+  private String unhcrNumber;
+  private String unrwaFile;
+  private String unrwaNumber;
+  private String whatsapp;
+  private String textSearchId;
+  private String folderlink;
+  private String folderlinkAddress;
+  private String folderlinkCharacter;
+  private String folderlinkEmployer;
+  private String folderlinkEngagement;
+  private String folderlinkExperience;
+  private String folderlinkFamily;
+  private String folderlinkIdentity;
+  private String folderlinkImmigration;
+  private String folderlinkLanguage;
+  private String folderlinkMedical;
+  private String folderlinkQualification;
+  private String folderlinkRegistration;
+  private String sflink;
+  private String videolink;
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class Candidate {\n");
-    sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
+    sb.append("class IdentifiableCandidate {\n");
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    additionalInfo: ").append(toIndentedString(additionalInfo)).append("\n");
     sb.append("    asylumYear: ").append(toIndentedString(asylumYear)).append("\n");
     sb.append("    arrestImprison: ").append(toIndentedString(arrestImprison)).append("\n");
@@ -393,6 +402,43 @@ public class CandidateDocument {
     sb.append("    createdDate: ").append(toIndentedString(createdDate)).append("\n");
     sb.append("    updatedBy: ").append(toIndentedString(updatedBy)).append("\n");
     sb.append("    updatedDate: ").append(toIndentedString(updatedDate)).append("\n");
+    sb.append("    candidateNumber: ").append(toIndentedString(candidateNumber)).append("\n");
+    sb.append("    dob: ").append(toIndentedString(dob)).append("\n");
+    sb.append("    externalId: ").append(toIndentedString(externalId)).append("\n");
+    sb.append("    externalIdSource: ").append(toIndentedString(externalIdSource)).append("\n");
+    sb.append("    linkedInLink: ").append(toIndentedString(linkedInLink)).append("\n");
+    sb.append("    phone: ").append(toIndentedString(phone)).append("\n");
+    sb.append("    address1: ").append(toIndentedString(address1)).append("\n");
+    sb.append("    regoIp: ").append(toIndentedString(regoIp)).append("\n");
+    sb.append("    regoPartnerParam: ").append(toIndentedString(regoPartnerParam)).append("\n");
+    sb.append("    regoReferrerParam: ").append(toIndentedString(regoReferrerParam)).append("\n");
+    sb.append("    regoUtmCampaign: ").append(toIndentedString(regoUtmCampaign)).append("\n");
+    sb.append("    regoUtmContent: ").append(toIndentedString(regoUtmContent)).append("\n");
+    sb.append("    regoUtmMedium: ").append(toIndentedString(regoUtmMedium)).append("\n");
+    sb.append("    regoUtmSource: ").append(toIndentedString(regoUtmSource)).append("\n");
+    sb.append("    regoUtmTerm: ").append(toIndentedString(regoUtmTerm)).append("\n");
+    sb.append("    user: ").append(toIndentedString(user)).append("\n");
+    sb.append("    unhcrFile: ").append(toIndentedString(unhcrFile)).append("\n");
+    sb.append("    unhcrNumber: ").append(toIndentedString(unhcrNumber)).append("\n");
+    sb.append("    unrwaFile: ").append(toIndentedString(unrwaFile)).append("\n");
+    sb.append("    unrwaNumber: ").append(toIndentedString(unrwaNumber)).append("\n");
+    sb.append("    whatsapp: ").append(toIndentedString(whatsapp)).append("\n");
+    sb.append("    textSearchId: ").append(toIndentedString(textSearchId)).append("\n");
+    sb.append("    folderlink: ").append(toIndentedString(folderlink)).append("\n");
+    sb.append("    folderlinkAddress: ").append(toIndentedString(folderlinkAddress)).append("\n");
+    sb.append("    folderlinkCharacter: ").append(toIndentedString(folderlinkCharacter)).append("\n");
+    sb.append("    folderlinkEmployer: ").append(toIndentedString(folderlinkEmployer)).append("\n");
+    sb.append("    folderlinkEngagement: ").append(toIndentedString(folderlinkEngagement)).append("\n");
+    sb.append("    folderlinkExperience: ").append(toIndentedString(folderlinkExperience)).append("\n");
+    sb.append("    folderlinkFamily: ").append(toIndentedString(folderlinkFamily)).append("\n");
+    sb.append("    folderlinkIdentity: ").append(toIndentedString(folderlinkIdentity)).append("\n");
+    sb.append("    folderlinkImmigration: ").append(toIndentedString(folderlinkImmigration)).append("\n");
+    sb.append("    folderlinkLanguage: ").append(toIndentedString(folderlinkLanguage)).append("\n");
+    sb.append("    folderlinkMedical: ").append(toIndentedString(folderlinkMedical)).append("\n");
+    sb.append("    folderlinkQualification: ").append(toIndentedString(folderlinkQualification)).append("\n");
+    sb.append("    folderlinkRegistration: ").append(toIndentedString(folderlinkRegistration)).append("\n");
+    sb.append("    sflink: ").append(toIndentedString(sflink)).append("\n");
+    sb.append("    videolink: ").append(toIndentedString(videolink)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -407,6 +453,5 @@ public class CandidateDocument {
     }
     return o.toString().replace("\n", "\n    ");
   }
-
 }
 

--- a/src/main/java/org/tctalent/anonymization/exception/RestApiReaderException.java
+++ b/src/main/java/org/tctalent/anonymization/exception/RestApiReaderException.java
@@ -1,0 +1,19 @@
+package org.tctalent.anonymization.exception;
+
+public class RestApiReaderException extends ServiceException {
+
+  private static final String REST_API_READER_EXCEPTION_CODE = "rest_api_read_failed";
+
+  public RestApiReaderException(String code, String message, Throwable cause) {
+    super(code, message, cause);
+  }
+
+  public RestApiReaderException(String message, Throwable cause) {
+    this(REST_API_READER_EXCEPTION_CODE, message, cause);
+  }
+
+  public RestApiReaderException(String message) {
+    super(REST_API_READER_EXCEPTION_CODE, message);
+  }
+
+}

--- a/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
@@ -14,16 +14,40 @@ import org.tctalent.anonymization.entity.mongo.CandidateDocument;
 })
 public interface CandidateMapper {
 
-  // Mongo to Open API:
+  /**
+   * Maps a Mongo {@link CandidateDocument} to an Open API {@link Candidate} model.
+   *
+   * @param document the mongo candidate document
+   * @return the corresponding open api model
+   */
   Candidate toCandidateModel(CandidateDocument document);
+
+  /**
+   * Maps a Page of {@link Candidate} models to an Open API {@link CandidatePage} model.
+   *
+   * @param page the page of candidates
+   * @return the corresponding open api model
+   */
   CandidatePage toCandidateModelPage(Page<Candidate> page);
 
-  // TC entity to Mongo
+  /**
+   * Maps a TC database {@link org.tctalent.anonymization.entity.db.Candidate} entity to an
+   * anonymised Mongo {@link CandidateDocument}.
+   *
+   * @param entity the database candidate entity
+   * @return the corresponding anonymised mongo document
+   */
   @Mapping(source = "id", target = "uuid") // todo sm this mocks a uuid based on the id - remove it when uuid's are sent from tc
   @Mapping(source = "createdDate", target = "createdDate")
   CandidateDocument anonymize(org.tctalent.anonymization.entity.db.Candidate entity);
 
-  // TC api to Mongo
+  /**
+   * Maps from an {@link IdentifiableCandidate} model to an anonymised Mongo
+   * {@link CandidateDocument}.
+   *
+   * @param model the identifiable candidate model
+   * @return the corresponding anonymised mongo document
+   */
   @Mapping(source = "id", target = "uuid") // todo sm this mocks a uuid based on the id - remove it when uuid's are sent from tc
-  CandidateDocument anonymize(IdentifiableCandidate identifiableCandidate);
+  CandidateDocument anonymize(IdentifiableCandidate model);
 }

--- a/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
@@ -5,6 +5,7 @@ import org.mapstruct.Mapping;
 import org.springframework.data.domain.Page;
 import org.tctalent.anonymization.model.Candidate;
 import org.tctalent.anonymization.model.CandidatePage;
+import org.tctalent.anonymization.model.IdentifiableCandidate;
 import org.tctalent.anonymization.entity.mongo.CandidateDocument;
 
 @Mapper(uses = {
@@ -13,14 +14,16 @@ import org.tctalent.anonymization.entity.mongo.CandidateDocument;
 })
 public interface CandidateMapper {
 
-  @Mapping(source = "id", target = "id")
-  Candidate toModel(org.tctalent.anonymization.entity.db.Candidate entity);
+  // Mongo to Open API:
+  Candidate toCandidateModel(CandidateDocument document);
+  CandidatePage toCandidateModelPage(Page<Candidate> page);
 
-  Candidate toModel(CandidateDocument document);
-
-  CandidatePage toCandidatePage(Page<Candidate> page);
-
-  @Mapping(source = "id", target = "id")
+  // TC entity to Mongo
+  @Mapping(source = "id", target = "uuid") // todo sm this mocks a uuid based on the id - remove it when uuid's are sent from tc
   @Mapping(source = "createdDate", target = "createdDate")
-  CandidateDocument toDocument(org.tctalent.anonymization.entity.db.Candidate entity);
+  CandidateDocument anonymize(org.tctalent.anonymization.entity.db.Candidate entity);
+
+  // TC api to Mongo
+  @Mapping(source = "id", target = "uuid") // todo sm this mocks a uuid based on the id - remove it when uuid's are sent from tc
+  CandidateDocument anonymize(IdentifiableCandidate identifiableCandidate);
 }

--- a/src/main/java/org/tctalent/anonymization/mapper/IdMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/IdMapper.java
@@ -9,6 +9,11 @@ public interface IdMapper {
     return value == null ? null : new UUID(0, value); // todo - dummy conversion
   }
 
+  default UUID map(String value) {
+    UUID uuid = value == null ? null : new UUID(0, Long.parseLong(value)); // todo - dummy conversion
+    return uuid;
+  }
+
   default Long map(UUID value) {
     return value == null ? null : value.getLeastSignificantBits(); // todo - dummy reverse conversion
   }

--- a/src/main/java/org/tctalent/anonymization/repository/CandidateMongoRepository.java
+++ b/src/main/java/org/tctalent/anonymization/repository/CandidateMongoRepository.java
@@ -8,5 +8,5 @@ import org.tctalent.anonymization.entity.mongo.CandidateDocument;
 
 @Repository
 public interface CandidateMongoRepository extends MongoRepository<CandidateDocument, String> {
-  Optional<CandidateDocument> findById(UUID id);
+  Optional<CandidateDocument> findByUuid(UUID uuid);
 }

--- a/src/main/java/org/tctalent/anonymization/response/JwtAuthenticationResponse.java
+++ b/src/main/java/org/tctalent/anonymization/response/JwtAuthenticationResponse.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Talent Beyond Boundaries.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.tctalent.anonymization.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.tctalent.anonymization.entity.db.User;
+
+@Getter
+@Setter
+public class JwtAuthenticationResponse {
+
+    private User user;
+    private String accessToken;
+    private String tokenType = "Bearer";
+
+    public JwtAuthenticationResponse(String accessToken, User user) {
+        this.accessToken = accessToken;
+        this.user = user;
+    }
+
+}

--- a/src/main/java/org/tctalent/anonymization/response/JwtAuthenticationResponse.java
+++ b/src/main/java/org/tctalent/anonymization/response/JwtAuthenticationResponse.java
@@ -16,6 +16,8 @@
 
 package org.tctalent.anonymization.response;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 import org.tctalent.anonymization.entity.db.User;
@@ -28,7 +30,11 @@ public class JwtAuthenticationResponse {
     private String accessToken;
     private String tokenType = "Bearer";
 
-    public JwtAuthenticationResponse(String accessToken, User user) {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public JwtAuthenticationResponse(
+        @JsonProperty("accessToken") String accessToken,
+        @JsonProperty("user") User user) {
+
         this.accessToken = accessToken;
         this.user = user;
     }

--- a/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
@@ -21,16 +21,16 @@ public class CandidateServiceImpl implements CandidateService {
   public CandidatePage findAll(Pageable pageable) {
     Page<Candidate> candidatePage =  candidateMongoRepository
         .findAll(pageable)
-        .map(candidateMapper::toModel);
+        .map(candidateMapper::toCandidateModel);
 
-    return candidateMapper.toCandidatePage(candidatePage);
+    return candidateMapper.toCandidateModelPage(candidatePage);
   }
 
   @Override
   public Candidate findById(UUID id) {
     return candidateMongoRepository
-        .findById(id)
-        .map(candidateMapper::toModel)
+        .findByUuid(id)
+        .map(candidateMapper::toCandidateModel)
         .orElseThrow(() -> new RuntimeException("Candidate not found")); // todo better exceptions
   }
 

--- a/src/main/java/org/tctalent/anonymization/service/TalentCatalogService.java
+++ b/src/main/java/org/tctalent/anonymization/service/TalentCatalogService.java
@@ -33,12 +33,13 @@ public interface TalentCatalogService {
   String fetchPageOfCandidateDataAsJson(int pageNumber) throws RestClientException;
 
   /**
-   * Returns the given page number of identifiable candidate data.
+   * Returns the given page number and page size of identifiable candidate data.
    * <p/>
    * Uses a default TC search request.
    * @param pageNumber Page number
-   * @return CandidatePage Page of candidates
+   * @param pageSize Page size
+   * @return IdentifiableCandidatePage Page of candidates
    * @throws RestClientException if errors are returned (eg unauthorized)
    */
-  IdentifiableCandidatePage fetchPageOfIdentifiableCandidateData(int pageNumber) throws RestClientException;
+  IdentifiableCandidatePage fetchPageOfIdentifiableCandidateData(int pageNumber, int pageSize) throws RestClientException;
 }

--- a/src/main/java/org/tctalent/anonymization/service/TalentCatalogService.java
+++ b/src/main/java/org/tctalent/anonymization/service/TalentCatalogService.java
@@ -1,0 +1,33 @@
+package org.tctalent.anonymization.service;
+
+import org.springframework.web.client.RestClientException;
+
+/**
+ * Access the main Talent Catalog Server
+ *
+ * @author John Cameron
+ */
+public interface TalentCatalogService {
+
+  /**
+   * True if we are currently logged in to the TC.
+   * @return True if logged in
+   */
+  boolean isLoggedIn();
+
+  /**
+   * Logs in to TC server with app password
+   * @throws RestClientException If login failed
+   */
+  void login() throws RestClientException;
+
+  /**
+   * Returns the given page number of candidate data.
+   * <p/>
+   * Uses a default TC search request.
+   * @param pageNumber Page number
+   * @return Page of candidates encoded as JSON strings
+   * @throws RestClientException if errors are returned (eg unauthorized)
+   */
+  String fetchPageOfCandidateDataAsJson(int pageNumber) throws RestClientException;
+}

--- a/src/main/java/org/tctalent/anonymization/service/TalentCatalogService.java
+++ b/src/main/java/org/tctalent/anonymization/service/TalentCatalogService.java
@@ -1,6 +1,7 @@
 package org.tctalent.anonymization.service;
 
 import org.springframework.web.client.RestClientException;
+import org.tctalent.anonymization.model.IdentifiableCandidatePage;
 
 /**
  * Access the main Talent Catalog Server
@@ -30,4 +31,14 @@ public interface TalentCatalogService {
    * @throws RestClientException if errors are returned (eg unauthorized)
    */
   String fetchPageOfCandidateDataAsJson(int pageNumber) throws RestClientException;
+
+  /**
+   * Returns the given page number of identifiable candidate data.
+   * <p/>
+   * Uses a default TC search request.
+   * @param pageNumber Page number
+   * @return CandidatePage Page of candidates
+   * @throws RestClientException if errors are returned (eg unauthorized)
+   */
+  IdentifiableCandidatePage fetchPageOfIdentifiableCandidateData(int pageNumber) throws RestClientException;
 }

--- a/src/main/java/org/tctalent/anonymization/service/TalentCatalogServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/TalentCatalogServiceImpl.java
@@ -1,0 +1,71 @@
+package org.tctalent.anonymization.service;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.tctalent.anonymization.request.LoginRequest;
+import org.tctalent.anonymization.request.candidate.SavedSearchGetRequest;
+import org.tctalent.anonymization.response.JwtAuthenticationResponse;
+
+/**
+ * @author John Cameron
+ */
+@Service
+public class TalentCatalogServiceImpl implements TalentCatalogService {
+  private JwtAuthenticationResponse credentials;
+
+  private final RestClient restClient;
+  private long savedSearchId = 408; //TODO JC Config - need to pass in real Search id
+  private String apiUrl = "http://localhost:8080/api/admin"; //TODO config
+
+  public TalentCatalogServiceImpl(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder.baseUrl(apiUrl).build();
+  }
+
+  @Override
+  public void login() throws RestClientException {
+    LoginRequest request = new LoginRequest();
+    request.setUsername("appAnonDatabaseService"); // todo sm config
+    request.setPassword("12345678"); // todo sm config environment variable
+
+    credentials = restClient.post()
+        .uri("/auth/login")
+        .contentType(APPLICATION_JSON)
+        .body(request)
+        .retrieve()
+        .body(JwtAuthenticationResponse.class);
+  }
+
+  @Override
+  public String fetchPageOfCandidateDataAsJson(int pageNumber) {
+    try {
+      SavedSearchGetRequest request = new SavedSearchGetRequest();
+      request.setPageSize(100);
+      request.setPageNumber(pageNumber);
+      return restClient.post()
+          .uri("/saved-search-candidate/" + savedSearchId + "/search-paged")
+          .contentType(APPLICATION_JSON)
+          .header(HttpHeaders.AUTHORIZATION,
+              credentials.getTokenType() + " " + credentials.getAccessToken())
+          .body(request)
+          .retrieve()
+          .body(String.class);
+    } catch (HttpClientErrorException e) {
+      //Check for logged out
+      if (e.getStatusCode().isSameCodeAs(HttpStatus.UNAUTHORIZED)) {
+        credentials = null;
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean isLoggedIn() {
+    return credentials != null;
+  }
+}

--- a/src/main/java/org/tctalent/anonymization/service/TalentCatalogServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/TalentCatalogServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
+import org.tctalent.anonymization.model.IdentifiableCandidatePage;
 import org.tctalent.anonymization.request.LoginRequest;
 import org.tctalent.anonymization.request.candidate.SavedSearchGetRequest;
 import org.tctalent.anonymization.response.JwtAuthenticationResponse;
@@ -20,7 +21,7 @@ public class TalentCatalogServiceImpl implements TalentCatalogService {
   private JwtAuthenticationResponse credentials;
 
   private final RestClient restClient;
-  private long savedSearchId = 408; //TODO JC Config - need to pass in real Search id
+  private long savedSearchId = 4672; //TODO JC Config - need to pass in real Search id
   private String apiUrl = "http://localhost:8080/api/admin"; //TODO config
 
   public TalentCatalogServiceImpl(RestClient.Builder restClientBuilder) {
@@ -55,6 +56,29 @@ public class TalentCatalogServiceImpl implements TalentCatalogService {
           .body(request)
           .retrieve()
           .body(String.class);
+    } catch (HttpClientErrorException e) {
+      //Check for logged out
+      if (e.getStatusCode().isSameCodeAs(HttpStatus.UNAUTHORIZED)) {
+        credentials = null;
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public IdentifiableCandidatePage fetchPageOfIdentifiableCandidateData(int pageNumber) throws RestClientException {
+    try {
+      SavedSearchGetRequest request = new SavedSearchGetRequest();
+      request.setPageSize(100);
+      request.setPageNumber(pageNumber);
+      return restClient.post()
+          .uri("/saved-search-candidate/" + savedSearchId + "/search-paged")
+          .contentType(APPLICATION_JSON)
+          .header(HttpHeaders.AUTHORIZATION,
+              credentials.getTokenType() + " " + credentials.getAccessToken())
+          .body(request)
+          .retrieve()
+          .body(IdentifiableCandidatePage.class);
     } catch (HttpClientErrorException e) {
       //Check for logged out
       if (e.getStatusCode().isSameCodeAs(HttpStatus.UNAUTHORIZED)) {

--- a/src/main/java/org/tctalent/anonymization/service/TalentCatalogServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/TalentCatalogServiceImpl.java
@@ -69,7 +69,7 @@ public class TalentCatalogServiceImpl implements TalentCatalogService {
   public IdentifiableCandidatePage fetchPageOfIdentifiableCandidateData(int pageNumber) throws RestClientException {
     try {
       SavedSearchGetRequest request = new SavedSearchGetRequest();
-      request.setPageSize(100);
+      request.setPageSize(100); // todo - sm - parameterise
       request.setPageNumber(pageNumber);
       return restClient.post()
           .uri("/saved-search-candidate/" + savedSearchId + "/search-paged")

--- a/src/main/java/org/tctalent/anonymization/util/RestPage.java
+++ b/src/main/java/org/tctalent/anonymization/util/RestPage.java
@@ -1,0 +1,34 @@
+package org.tctalent.anonymization.util;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+/**
+ * Jackson can't deserialize PageImpl.
+ * <p/>
+ * From <a href="https://stackoverflow.com/a/71515470/929968">Stackoverflow</a>
+ *
+ * @author John Camaron
+ */
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"})
+public class RestPage<T> extends PageImpl<T> {
+
+  @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+  public RestPage(@JsonProperty("content") List<T> content,
+      @JsonProperty("number") int page,
+      @JsonProperty("size") int size,
+      @JsonProperty("totalElements") long total) {
+
+    //TODO JC Hard code size because not currently being returned by TC server. See DtoBuilder.buildPage
+    super(content, PageRequest.of(page, 100), total);
+  }
+
+  public RestPage(Page<T> page) {
+    super(page.getContent(), page.getPageable(), page.getTotalElements());
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,8 +2,16 @@ server:
   port: ${SERVER_PORT:8082}
 
 batch:
-  chunk-size: 100
-  page-size: 100
+  chunk-size: ${BATCH_CHUNK_SIZE:100}
+  page-size: ${BATCH_PAGE_SIZE:100}
+  max-read-skips: ${BATCH_MAX_READ_SKIPS:10}
+  fetch-delay-millis: ${BATCH_FETCH_DELAY_MILLIS:1000}
+
+tc-service:
+  apiUrl: ${TC_API_URL:http://localhost:8080/api/admin}
+  search-id: ${TC_SEARCH_ID:4672}
+  username: ${TC_USERNAME:appAnonDatabaseService}
+  password: ${TC_PASSWORD:12345678} # todo - sm - just a dummy value for local testing
 
 spring:
   application:
@@ -44,7 +52,7 @@ spring:
     jdbc:
       initialize-schema: always # see todo above
     job:
-      enabled: false # disables auto-run of jobs
+      enabled: true # disables auto-run of jobs
 
 # for prototyping with TC entities
 jwt:
@@ -73,3 +81,4 @@ web:
   # This is used in EmailHelper
   # and SiteRedirectController to redirect urls from the Version 1 TC to the Version 2 TC
   admin: https://tctalent.org/admin-portal
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,5 @@
 server:
-  port:
-    8082
+  port: ${SERVER_PORT:8082}
 
 batch:
   chunk-size: 100

--- a/src/test/java/org/tctalent/anonymization/batch/BatchConfigTest.java
+++ b/src/test/java/org/tctalent/anonymization/batch/BatchConfigTest.java
@@ -1,0 +1,133 @@
+package org.tctalent.anonymization.batch;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.tctalent.anonymization.entity.db.Candidate;
+import org.tctalent.anonymization.entity.mongo.CandidateDocument;
+import org.tctalent.anonymization.model.IdentifiableCandidate;
+import org.tctalent.anonymization.repository.CandidateMongoRepository;
+import org.tctalent.anonymization.repository.CandidateRepository;
+
+/**
+ * Unit tests for the {@link BatchConfig} class.
+ *
+ * @author sadatmalik
+ */
+class BatchConfigTest {
+
+  @Mock private BatchProperties batchProperties;
+  @Mock private JobRepository jobRepository;
+  @Mock private DataSourceTransactionManager transactionManager;
+  @Mock private ItemReader<Candidate> jpaItemReader;
+  @Mock private ItemProcessor<Candidate, CandidateDocument> jpaItemProcessor;
+  @Mock private ItemProcessor<IdentifiableCandidate, CandidateDocument> restItemProcessor;
+  @Mock private ItemWriter<CandidateDocument> mongoItemWriter;
+  @Mock private LoggingChunkListener loggingChunkListener;
+  @Mock private LoggingItemReaderListener loggingItemReaderListener;
+  @Mock private LoggingItemProcessListener loggingItemProcessListener;
+  @Mock private LoggingItemWriterListener loggingItemWriterListener;
+  @Mock private CandidateRepository candidateRepository;
+  @Mock private CandidateMongoRepository candidateMongoRepository;
+
+  @InjectMocks private BatchConfig batchConfig;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  @DisplayName("Test candidate migration job configuration")
+  void testCandidateMigrationJob() {
+    Step candidateMigrationStep = mock(Step.class);
+    JobCompletionNotificationListener listener = mock(JobCompletionNotificationListener.class);
+
+    Job job = batchConfig.candidateMigrationJob(jobRepository, candidateMigrationStep, listener);
+
+    assertNotNull(job);
+    assertEquals("candidateMigrationJob", job.getName());
+  }
+
+  @Test
+  @DisplayName("Test candidate JPA migration step configuration")
+  void testCandidateJpaMigrationStep() {
+    when(batchProperties
+        .getChunkSize())
+        .thenReturn(100);
+
+    Step step = batchConfig.candidateJpaMigrationStep(
+        jobRepository,
+        transactionManager,
+        jpaItemReader,
+        jpaItemProcessor,
+        mongoItemWriter,
+        loggingChunkListener,
+        loggingItemReaderListener,
+        loggingItemProcessListener,
+        loggingItemWriterListener
+    );
+
+    assertNotNull(step);
+    assertEquals("candidateJpaMigrationStep", step.getName());
+  }
+
+  @Test
+  @DisplayName("Test candidate REST migration step configuration")
+  void testCandidateRestMigrationStep() {
+    when(batchProperties
+        .getChunkSize())
+        .thenReturn(100);
+
+    ItemReader<IdentifiableCandidate> tcItemReader = mock(RestApiItemReader.class);
+
+    Step step = batchConfig.candidateRestMigrationStep(
+        jobRepository,
+        transactionManager,
+        tcItemReader,
+        restItemProcessor,
+        mongoItemWriter,
+        loggingChunkListener,
+        loggingItemReaderListener,
+        loggingItemProcessListener,
+        loggingItemWriterListener
+    );
+
+    assertNotNull(step);
+    assertEquals("candidateRestMigrationStep", step.getName());
+  }
+
+  @Test
+  @DisplayName("Test JPA item reader configuration")
+  void testJpaItemReader() {
+    when(batchProperties
+        .getPageSize())
+        .thenReturn(100);
+
+    ItemReader<Candidate> reader = batchConfig.jpaItemReader(candidateRepository);
+
+    assertNotNull(reader);
+  }
+
+  @Test
+  @DisplayName("Test Mongo item writer configuration")
+  void testMongoItemWriter() {
+    ItemWriter<CandidateDocument> writer = batchConfig.mongoItemWriter(candidateMongoRepository);
+
+    assertNotNull(writer);
+  }
+}

--- a/src/test/java/org/tctalent/anonymization/batch/BatchConfigTest.java
+++ b/src/test/java/org/tctalent/anonymization/batch/BatchConfigTest.java
@@ -3,7 +3,6 @@ package org.tctalent.anonymization.batch;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/tctalent/anonymization/batch/BatchPropertiesTest.java
+++ b/src/test/java/org/tctalent/anonymization/batch/BatchPropertiesTest.java
@@ -1,0 +1,35 @@
+package org.tctalent.anonymization.batch;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Test for {@link BatchProperties}.
+ *
+ * @author sadatmalik
+ */
+@SpringBootTest(classes = BatchProperties.class)
+@EnableConfigurationProperties(BatchProperties.class)
+@TestPropertySource(properties = {
+    "batch.chunk-size=100",
+    "batch.page-size=200"
+})
+class BatchPropertiesTest {
+
+  @Autowired
+  BatchProperties batchProperties;
+
+  @Test
+  @DisplayName("Test batch properties")
+  void testBatchProperties() {
+    assertEquals(100, batchProperties.getChunkSize());
+    assertEquals(200, batchProperties.getPageSize());
+  }
+}
+

--- a/src/test/java/org/tctalent/anonymization/batch/CandidateJpaItemProcessorTest.java
+++ b/src/test/java/org/tctalent/anonymization/batch/CandidateJpaItemProcessorTest.java
@@ -1,0 +1,49 @@
+package org.tctalent.anonymization.batch;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.tctalent.anonymization.entity.db.Candidate;
+import org.tctalent.anonymization.entity.mongo.CandidateDocument;
+import org.tctalent.anonymization.mapper.CandidateMapper;
+
+/**
+ * Unit tests for the {@link CandidateJpaItemProcessor} class.
+ *
+ * @author sadatmalik
+ */
+class CandidateJpaItemProcessorTest {
+
+  @Mock
+  private CandidateMapper candidateMapper;
+
+  @InjectMocks
+  private CandidateJpaItemProcessor candidateJpaItemProcessor;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  @DisplayName("Test jpa item processes")
+  void testProcess() {
+    Candidate candidate = new Candidate();
+    CandidateDocument candidateDocument = new CandidateDocument();
+
+    when(candidateMapper
+        .anonymize(candidate))
+        .thenReturn(candidateDocument);
+
+    CandidateDocument result = candidateJpaItemProcessor.process(candidate);
+
+    assertEquals(candidateDocument, result);
+    verify(candidateMapper).anonymize(candidate);
+  }
+}

--- a/src/test/java/org/tctalent/anonymization/batch/CandidateRestItemProcessorTest.java
+++ b/src/test/java/org/tctalent/anonymization/batch/CandidateRestItemProcessorTest.java
@@ -1,0 +1,49 @@
+package org.tctalent.anonymization.batch;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.tctalent.anonymization.entity.mongo.CandidateDocument;
+import org.tctalent.anonymization.mapper.CandidateMapper;
+import org.tctalent.anonymization.model.IdentifiableCandidate;
+
+/**
+ * Unit tests for the {@link CandidateRestItemProcessor} class.
+ *
+ * @author sadatmalik
+ */
+class CandidateRestItemProcessorTest {
+
+  @Mock
+  private CandidateMapper candidateMapper;
+
+  @InjectMocks
+  private CandidateRestItemProcessor candidateRestItemProcessor;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  @DisplayName("Test rest item processes")
+  void testProcess() {
+    IdentifiableCandidate identifiableCandidate = new IdentifiableCandidate();
+    CandidateDocument candidateDocument = new CandidateDocument();
+
+    when(candidateMapper
+        .anonymize(identifiableCandidate))
+        .thenReturn(candidateDocument);
+
+    CandidateDocument result = candidateRestItemProcessor.process(identifiableCandidate);
+
+    assertEquals(candidateDocument, result);
+    verify(candidateMapper).anonymize(identifiableCandidate);
+  }
+}

--- a/src/test/java/org/tctalent/anonymization/batch/ConditionalSkipPolicyTest.java
+++ b/src/test/java/org/tctalent/anonymization/batch/ConditionalSkipPolicyTest.java
@@ -1,0 +1,51 @@
+package org.tctalent.anonymization.batch;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.tctalent.anonymization.exception.RestApiReaderException;
+
+/**
+ * Unit tests for the {@link ConditionalSkipPolicy} class.
+ *
+ * @author sadatmalik
+ */
+class ConditionalSkipPolicyTest {
+
+  private ConditionalSkipPolicy skipPolicy;
+
+  @BeforeEach
+  void setUp() {
+    skipPolicy = new ConditionalSkipPolicy(3); // Set max skips to 3 for testing
+  }
+
+  @Test
+  @DisplayName("Test should skip on non-RestApiReaderException")
+  void testShouldSkip_NonRestApiReaderException() {
+    Throwable nonRestApiException = new RuntimeException("Non-RestApiReaderException");
+    assertTrue(skipPolicy.shouldSkip(nonRestApiException, 0));
+  }
+
+  @Test
+  @DisplayName("Test should skip on RestApiReaderException within limit")
+  void testShouldSkip_RestApiReaderException_WithinLimit() {
+    Throwable restApiException = new RestApiReaderException("RestApiReaderException");
+
+    assertTrue(skipPolicy.shouldSkip(restApiException, 0));
+    assertTrue(skipPolicy.shouldSkip(restApiException, 1));
+    assertTrue(skipPolicy.shouldSkip(restApiException, 2));
+  }
+
+  @Test
+  @DisplayName("Test should fail job on RestApiReaderException exceeds limit")
+  void testShouldSkip_RestApiReaderException_ExceedsLimit() {
+    Throwable restApiException = new RestApiReaderException("RestApiReaderException");
+
+    assertTrue(skipPolicy.shouldSkip(restApiException, 0));
+    assertTrue(skipPolicy.shouldSkip(restApiException, 1));
+    assertTrue(skipPolicy.shouldSkip(restApiException, 2));
+    assertFalse(skipPolicy.shouldSkip(restApiException, 3)); // Exceeds limit
+  }
+}

--- a/src/test/java/org/tctalent/anonymization/batch/RestApiItemReaderTest.java
+++ b/src/test/java/org/tctalent/anonymization/batch/RestApiItemReaderTest.java
@@ -22,8 +22,8 @@ import org.tctalent.anonymization.service.TalentCatalogService;
  */
 class RestApiItemReaderTest {
 
-  @Mock
-  private TalentCatalogService talentCatalogService;
+  @Mock private TalentCatalogService talentCatalogService;
+  @Mock private BatchProperties batchProperties;
 
   @InjectMocks
   private RestApiItemReader restApiItemReader;
@@ -31,11 +31,13 @@ class RestApiItemReaderTest {
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
+    when(batchProperties.getFetchDelayMillis()).thenReturn(1000L);
+    when(batchProperties.getPageSize()).thenReturn(100);
   }
 
   @Test
   @DisplayName("Test read")
-  void testRead() throws Exception {
+  void testRead() {
     IdentifiableCandidate candidate1 = new IdentifiableCandidate();
     IdentifiableCandidate candidate2 = new IdentifiableCandidate();
     IdentifiableCandidatePage page = new IdentifiableCandidatePage();
@@ -43,7 +45,7 @@ class RestApiItemReaderTest {
     page.setTotalPages(1);
 
     when(talentCatalogService
-        .fetchPageOfIdentifiableCandidateData(0))
+        .fetchPageOfIdentifiableCandidateData(0, 100))
         .thenReturn(page);
 
     IdentifiableCandidate result1 = restApiItemReader.read();
@@ -57,7 +59,7 @@ class RestApiItemReaderTest {
 
   @Test
   @DisplayName("Test read fetches next batch when batch iterator is null")
-  void testReadFetchesNextBatchWhenBatchIteratorIsNull() throws Exception {
+  void testReadFetchesNextBatchWhenBatchIteratorIsNull() {
     IdentifiableCandidate candidate = new IdentifiableCandidate();
     IdentifiableCandidatePage page = new IdentifiableCandidatePage();
     page.setContent(List.of(candidate));
@@ -68,14 +70,14 @@ class RestApiItemReaderTest {
         .thenReturn(true);
 
     when(talentCatalogService
-        .fetchPageOfIdentifiableCandidateData(0))
+        .fetchPageOfIdentifiableCandidateData(0, 100))
         .thenReturn(page);
 
     IdentifiableCandidate result = restApiItemReader.read();
 
     assertNotNull(result, "The returned candidate should not be null");
     assertEquals(candidate, result, "The returned candidate should match the fetched batch");
-    verify(talentCatalogService).fetchPageOfIdentifiableCandidateData(0);
+    verify(talentCatalogService).fetchPageOfIdentifiableCandidateData(0, 100);
   }
 
   @Test
@@ -101,7 +103,7 @@ class RestApiItemReaderTest {
         .thenReturn(true);
 
     when(talentCatalogService
-        .fetchPageOfIdentifiableCandidateData(0))
+        .fetchPageOfIdentifiableCandidateData(0, 100))
         .thenReturn(null);
 
     assertThrows(
@@ -112,7 +114,7 @@ class RestApiItemReaderTest {
 
   @Test
   @DisplayName("Test read fetches next batch and handles null content in response from API")
-  void testFetchNextBatchHandlesEmptyBatch() throws Exception {
+  void testFetchNextBatchHandlesEmptyBatch() {
     IdentifiableCandidatePage page = new IdentifiableCandidatePage();
     page.setContent(List.of());
     page.setTotalPages(1);
@@ -122,7 +124,7 @@ class RestApiItemReaderTest {
         .thenReturn(true);
 
     when(talentCatalogService
-        .fetchPageOfIdentifiableCandidateData(0))
+        .fetchPageOfIdentifiableCandidateData(0, 100))
         .thenReturn(page);
 
     IdentifiableCandidate result = restApiItemReader.read();
@@ -149,7 +151,7 @@ class RestApiItemReaderTest {
   @DisplayName("Test read with exception")
   void testReadWithException() {
     when(talentCatalogService
-        .fetchPageOfIdentifiableCandidateData(0))
+        .fetchPageOfIdentifiableCandidateData(0, 100))
         .thenThrow(new RestApiReaderException("Error"));
 
     assertThrows(

--- a/src/test/java/org/tctalent/anonymization/batch/RestApiItemReaderTest.java
+++ b/src/test/java/org/tctalent/anonymization/batch/RestApiItemReaderTest.java
@@ -1,0 +1,162 @@
+package org.tctalent.anonymization.batch;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.tctalent.anonymization.exception.RestApiReaderException;
+import org.tctalent.anonymization.model.IdentifiableCandidate;
+import org.tctalent.anonymization.model.IdentifiableCandidatePage;
+import org.tctalent.anonymization.service.TalentCatalogService;
+
+/**
+ * Unit tests for the {@link RestApiItemReader} class.
+ *
+ * @author sadatmalik
+ */
+class RestApiItemReaderTest {
+
+  @Mock
+  private TalentCatalogService talentCatalogService;
+
+  @InjectMocks
+  private RestApiItemReader restApiItemReader;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  @DisplayName("Test read")
+  void testRead() throws Exception {
+    IdentifiableCandidate candidate1 = new IdentifiableCandidate();
+    IdentifiableCandidate candidate2 = new IdentifiableCandidate();
+    IdentifiableCandidatePage page = new IdentifiableCandidatePage();
+    page.setContent(List.of(candidate1, candidate2));
+    page.setTotalPages(1);
+
+    when(talentCatalogService
+        .fetchPageOfIdentifiableCandidateData(0))
+        .thenReturn(page);
+
+    IdentifiableCandidate result1 = restApiItemReader.read();
+    IdentifiableCandidate result2 = restApiItemReader.read();
+    IdentifiableCandidate result3 = restApiItemReader.read();
+
+    assertEquals(candidate1, result1);
+    assertEquals(candidate2, result2);
+    assertNull(result3);
+  }
+
+  @Test
+  @DisplayName("Test read fetches next batch when batch iterator is null")
+  void testReadFetchesNextBatchWhenBatchIteratorIsNull() throws Exception {
+    IdentifiableCandidate candidate = new IdentifiableCandidate();
+    IdentifiableCandidatePage page = new IdentifiableCandidatePage();
+    page.setContent(List.of(candidate));
+    page.setTotalPages(1);
+
+    when(talentCatalogService
+        .isLoggedIn())
+        .thenReturn(true);
+
+    when(talentCatalogService
+        .fetchPageOfIdentifiableCandidateData(0))
+        .thenReturn(page);
+
+    IdentifiableCandidate result = restApiItemReader.read();
+
+    assertNotNull(result, "The returned candidate should not be null");
+    assertEquals(candidate, result, "The returned candidate should match the fetched batch");
+    verify(talentCatalogService).fetchPageOfIdentifiableCandidateData(0);
+  }
+
+  @Test
+  @DisplayName("Test read fetches next batch when batch iterator is empty")
+  void testFetchNextBatchCallsLoginWhenNotLoggedIn() {
+    when(talentCatalogService
+        .isLoggedIn())
+        .thenReturn(false);
+
+    assertThrows(
+        RestApiReaderException.class,
+        () -> restApiItemReader.read(),
+        "Should throw an exception if login fails or fetch is interrupted");
+
+    verify(talentCatalogService).login();
+  }
+
+  @Test
+  @DisplayName("Test read fetches next batch and handles null response from API")
+  void testFetchNextBatchHandlesNullResponseFromApi() {
+    when(talentCatalogService
+        .isLoggedIn())
+        .thenReturn(true);
+
+    when(talentCatalogService
+        .fetchPageOfIdentifiableCandidateData(0))
+        .thenReturn(null);
+
+    assertThrows(
+        RestApiReaderException.class,
+        () -> restApiItemReader.read(),
+        "Should throw an exception if the API response is null");
+  }
+
+  @Test
+  @DisplayName("Test read fetches next batch and handles null content in response from API")
+  void testFetchNextBatchHandlesEmptyBatch() throws Exception {
+    IdentifiableCandidatePage page = new IdentifiableCandidatePage();
+    page.setContent(List.of());
+    page.setTotalPages(1);
+
+    when(talentCatalogService
+        .isLoggedIn())
+        .thenReturn(true);
+
+    when(talentCatalogService
+        .fetchPageOfIdentifiableCandidateData(0))
+        .thenReturn(page);
+
+    IdentifiableCandidate result = restApiItemReader.read();
+
+    assertNull(result, "The returned candidate should be null when the batch is empty");
+  }
+
+  @Test
+  @DisplayName("Test read throws exception for unhandled errors")
+  void testReadThrowsExceptionForUnhandledErrors() {
+    when(talentCatalogService
+        .isLoggedIn())
+        .thenThrow(new RuntimeException("Unexpected error"));
+
+    Exception exception = assertThrows(
+        RestApiReaderException.class,
+        () -> restApiItemReader.read(),
+        "Should wrap unhandled exceptions in RestApiReaderException");
+
+    assertTrue(exception.getMessage().contains("Failed to read IdentifiableCandidate"));
+  }
+
+  @Test
+  @DisplayName("Test read with exception")
+  void testReadWithException() {
+    when(talentCatalogService
+        .fetchPageOfIdentifiableCandidateData(0))
+        .thenThrow(new RestApiReaderException("Error"));
+
+    assertThrows(
+        RestApiReaderException.class,
+        () -> restApiItemReader.read(),
+        "Should throw an exception if on API fetch error"
+    );
+  }
+
+}

--- a/src/test/java/org/tctalent/anonymization/controller/CandidateControllerTest.java
+++ b/src/test/java/org/tctalent/anonymization/controller/CandidateControllerTest.java
@@ -57,10 +57,10 @@ class CandidateControllerTest {
   @Transactional
   @DisplayName("Get candidate by Id")
   void testGetCandidateById() throws Exception {
-    mockMvc.perform(get(CandidateController.BASE_URL + "/{candidateId}", testCandidate.getId())
+    mockMvc.perform(get(CandidateController.BASE_URL + "/{candidateId}", testCandidate.getUuid())
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(testCandidate.getId().toString()));
+        .andExpect(jsonPath("$.id").value(testCandidate.getUuid().toString()));
   }
 
 }

--- a/src/test/java/org/tctalent/anonymization/exception/RestApiReaderExceptionTest.java
+++ b/src/test/java/org/tctalent/anonymization/exception/RestApiReaderExceptionTest.java
@@ -1,0 +1,49 @@
+package org.tctalent.anonymization.exception;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link RestApiReaderException} class.
+ *
+ * @author sadatmalik
+ */
+class RestApiReaderExceptionTest {
+
+  @Test
+  @DisplayName("Test constructor with message")
+  void testConstructorWithMessage() {
+    String message = "Test message";
+    RestApiReaderException exception = new RestApiReaderException(message);
+
+    assertEquals("rest_api_read_failed", exception.getErrorCode());
+    assertEquals(message, exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("Test constructor with message and cause")
+  void testConstructorWithMessageAndCause() {
+    String message = "Test message";
+    Throwable cause = new RuntimeException("Cause");
+    RestApiReaderException exception = new RestApiReaderException(message, cause);
+
+    assertEquals("rest_api_read_failed", exception.getErrorCode());
+    assertEquals(message, exception.getMessage());
+    assertEquals(cause, exception.getCause());
+  }
+
+  @Test
+  @DisplayName("Test constructor with code, message and cause")
+  void testConstructorWithCodeMessageAndCause() {
+    String code = "custom_code";
+    String message = "Test message";
+    Throwable cause = new RuntimeException("Cause");
+    RestApiReaderException exception = new RestApiReaderException(code, message, cause);
+
+    assertEquals(code, exception.getErrorCode());
+    assertEquals(message, exception.getMessage());
+    assertEquals(cause, exception.getCause());
+  }
+}

--- a/src/test/java/org/tctalent/anonymization/mapper/DateTimeMapperTest.java
+++ b/src/test/java/org/tctalent/anonymization/mapper/DateTimeMapperTest.java
@@ -1,0 +1,63 @@
+package org.tctalent.anonymization.mapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Unit tests for the {@link DateTimeMapper} class.
+ *
+ * @author sadatmalik
+ */
+class DateTimeMapperTest {
+
+  private DateTimeMapper dateTimeMapper;
+
+  @BeforeEach
+  void setUp() {
+    dateTimeMapper = Mappers.getMapper(DateTimeMapper.class);
+  }
+
+  @Test
+  @DisplayName("Test instant to offset date time mapping")
+  void testToOffsetDateTime() {
+    Instant instant = Instant.parse("2023-01-01T00:00:00Z");
+    OffsetDateTime offsetDateTime = dateTimeMapper.toOffsetDateTime(instant);
+
+    assertNotNull(offsetDateTime);
+    assertEquals(instant, offsetDateTime.toInstant());
+    assertEquals(ZoneOffset.UTC, offsetDateTime.getOffset());
+  }
+
+  @Test
+  @DisplayName("Test instant to offset date time mapping with null")
+  void testToOffsetDateTime_Null() {
+    OffsetDateTime offsetDateTime = dateTimeMapper.toOffsetDateTime(null);
+
+    assertNull(offsetDateTime);
+  }
+
+  @Test
+  @DisplayName("Test offset date time to instant mapping")
+  void testToInstant() {
+    OffsetDateTime offsetDateTime = OffsetDateTime.parse("2024-12-13T00:00:00Z");
+    Instant instant = dateTimeMapper.toInstant(offsetDateTime);
+
+    assertNotNull(instant);
+    assertEquals(offsetDateTime.toInstant(), instant);
+  }
+
+  @Test
+  @DisplayName("Test offset date time to instant mapping with null")
+  void testToInstant_Null() {
+    Instant instant = dateTimeMapper.toInstant(null);
+
+    assertNull(instant);
+  }
+}

--- a/src/test/java/org/tctalent/anonymization/service/AnonymizationServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/AnonymizationServiceImplTest.java
@@ -37,6 +37,7 @@ class AnonymizationServiceImplTest {
     void anonymize() throws JsonProcessingException {
 
         UUID uuid = UUID.randomUUID();
+        String id = "123456";
 
         User user = User.builder()
             .firstName("John")
@@ -51,7 +52,8 @@ class AnonymizationServiceImplTest {
             .build();
 
         IdentifiableCandidate identifiableCandidate = IdentifiableCandidate.builder()
-            .id(uuid)
+            .id(id)
+            .uuid(uuid)
             .user(user)
             .phone("+1-234-567-890")
             .address1("123 Main St, Springfield, IL")
@@ -62,7 +64,7 @@ class AnonymizationServiceImplTest {
 
         Candidate candidate = service.anonymize(identifiableCandidate);
 
-        assertEquals(uuid, candidate.getId());
+        assertEquals(uuid, candidate.getUuid());
         System.out.println(candidate);
     }
 }

--- a/src/test/java/org/tctalent/anonymization/service/CandidateServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/CandidateServiceImplTest.java
@@ -1,0 +1,102 @@
+package org.tctalent.anonymization.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.tctalent.anonymization.entity.mongo.CandidateDocument;
+import org.tctalent.anonymization.mapper.CandidateMapper;
+import org.tctalent.anonymization.model.Candidate;
+import org.tctalent.anonymization.model.CandidatePage;
+import org.tctalent.anonymization.repository.CandidateMongoRepository;
+
+class CandidateServiceImplTest {
+
+  @Mock private CandidateMongoRepository candidateMongoRepository;
+  @Mock private CandidateMapper candidateMapper;
+
+  @InjectMocks private CandidateServiceImpl candidateService;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  @DisplayName("Test find all candidates")
+  void testFindAll() {
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<CandidateDocument> candidateDocumentPage = new PageImpl<>(List.of(new CandidateDocument()));
+    Candidate candidate = new Candidate();
+    Page<Candidate> candidatePage = new PageImpl<>(List.of(candidate));
+    CandidatePage expectedCandidatePage = new CandidatePage();
+
+    when(candidateMongoRepository
+        .findAll(pageable))
+        .thenReturn(candidateDocumentPage);
+
+    when(candidateMapper
+        .toCandidateModel(any(CandidateDocument.class)))
+        .thenReturn(candidate);
+
+    when(candidateMapper
+        .toCandidateModelPage(candidatePage))
+        .thenReturn(expectedCandidatePage);
+
+    CandidatePage result = candidateService.findAll(pageable);
+
+    assertNotNull(result);
+    assertEquals(expectedCandidatePage, result);
+  }
+
+  @Test
+  @DisplayName("Test find candidate by id")
+  void testFindById() {
+    UUID id = UUID.randomUUID();
+    CandidateDocument candidateDocument = new CandidateDocument();
+    Candidate candidate = new Candidate();
+
+    when(candidateMongoRepository
+        .findByUuid(id))
+        .thenReturn(Optional.of(candidateDocument));
+
+    when(candidateMapper
+        .toCandidateModel(candidateDocument))
+        .thenReturn(candidate);
+
+    Candidate result = candidateService.findById(id);
+
+    assertNotNull(result);
+    assertEquals(candidate, result);
+  }
+
+  @Test
+  @DisplayName("Test find candidate by id not found")
+  void testFindById_NotFound() {
+    UUID id = UUID.randomUUID();
+
+    when(candidateMongoRepository
+        .findByUuid(id))
+        .thenReturn(Optional.empty());
+
+    Exception exception = assertThrows(
+        RuntimeException.class,
+        () -> candidateService.findById(id),
+        "Should throw an exception if the candidate is not found"
+    );
+
+    assertEquals("Candidate not found", exception.getMessage());
+  }
+}

--- a/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
@@ -14,8 +14,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.client.RestClientException;
-import org.tctalent.anonymization.model.AnonCandidate;
-import org.tctalent.server.repository.AnonCandidateRepository;
+import org.tctalent.anonymization.model.IdentifiableCandidate;
+import org.tctalent.anonymization.repository.CandidateMongoRepository;
 import org.tctalent.util.background.BackProcessor;
 import org.tctalent.util.background.BackRunner;
 import org.tctalent.util.background.IdContext;
@@ -29,7 +29,7 @@ class TalentCatalogServiceImplTest {
   AnonymizationService anonymizationService;
 
   @Autowired
-  AnonCandidateRepository anonCandidateRepository;
+  CandidateMongoRepository anonCandidateRepository;
 
   @BeforeEach
   void setUp() {
@@ -57,86 +57,86 @@ class TalentCatalogServiceImplTest {
 
   @Test
   void loginAndFetchPageOfCandidateDataAsJson() {
-    try {
-      tcService.login();
-      assertTrue(tcService.isLoggedIn());
-
-      String pageOfDataAsJson = tcService.fetchPageOfCandidateDataAsJson(0);
-      assertNotNull(pageOfDataAsJson);
-
-      Page<AnonCandidate>
-          anonCandidates = anonymizationService.anonymizePage(pageOfDataAsJson);
-      assertNotNull(anonCandidates);
-      String collect = anonCandidates.stream()
-          .map(ca -> Long.toString(ca.getCandidateNumber()))
-          .collect(Collectors.joining(","));
-      System.out.println("Received numbers: " + collect);
-
-      anonCandidateRepository.saveAll(anonCandidates);
-      for (AnonCandidate customer : anonCandidateRepository.findAll()) {
-        System.out.println(customer);
-      }
-
-
-    } catch (RestClientException ex) {
-      fail(ex);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
+//    try {
+//      tcService.login();
+//      assertTrue(tcService.isLoggedIn());
+//
+//      String pageOfDataAsJson = tcService.fetchPageOfCandidateDataAsJson(0);
+//      assertNotNull(pageOfDataAsJson);
+//
+//      Page<AnonCandidate>
+//          anonCandidates = anonymizationService.anonymizePage(pageOfDataAsJson);
+//      assertNotNull(anonCandidates);
+//      String collect = anonCandidates.stream()
+//          .map(ca -> Long.toString(ca.getCandidateNumber()))
+//          .collect(Collectors.joining(","));
+//      System.out.println("Received numbers: " + collect);
+//
+//      anonCandidateRepository.saveAll(anonCandidates);
+//      for (AnonCandidate customer : anonCandidateRepository.findAll()) {
+//        System.out.println(customer);
+//      }
+//
+//
+//    } catch (RestClientException ex) {
+//      fail(ex);
+//    } catch (JsonProcessingException e) {
+//      throw new RuntimeException(e);
+//    }
   }
 
   @Test
   void loginAndFetchFirstFewPagesOfCandidateData() {
-    try {
-      tcService.login();
-      assertTrue(tcService.isLoggedIn());
-
-      BackRunner<IdContext> backRunner;
-      BackProcessor<IdContext> backProcessor;
-      ThreadPoolTaskScheduler taskScheduler;
-
-      taskScheduler = new ThreadPoolTaskScheduler();
-      taskScheduler.initialize();
-      backRunner = new BackRunner<>();
-      backProcessor = new BackProcessor<>() {
-        @Override
-        public boolean process(IdContext ctx) {
-          long startId = ctx.getLastProcessedId() == null ? 0 : ctx.getLastProcessedId()+1;
-          System.out.println("Processing " + ctx.getNumToProcess() + " ids starting from "
-              + (startId == 0 ? "beginning " : startId) );
-          String pageOfDataAsJson =
-              tcService.fetchPageOfCandidateDataAsJson((int) startId);
-          assertNotNull(pageOfDataAsJson);
-
-          Page<AnonCandidate>
-              anonCandidates = null;
-          try {
-            anonCandidates = anonymizationService.anonymizePage(pageOfDataAsJson);
-          } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-          }
-          assertNotNull(anonCandidates);
-          String collect = anonCandidates.stream()
-              .map(ca -> Long.toString(ca.getCandidateNumber()))
-              .collect(Collectors.joining(","));
-          System.out.println("Received numbers: " + collect);
-          long lastProcessed = startId + ctx.getNumToProcess() - 1;
-          ctx.setLastProcessedId(lastProcessed);
-          return lastProcessed+1 >= 50;
-        }
-      };
-
-      ScheduledFuture<?> scheduledFuture =
-          backRunner.start(taskScheduler, backProcessor,
-              new IdContext(null, 1),
-              10);
-
-      Thread.sleep(30000);
-
-    } catch (Exception ex) {
-      fail(ex);
-    }
+//    try {
+//      tcService.login();
+//      assertTrue(tcService.isLoggedIn());
+//
+//      BackRunner<IdContext> backRunner;
+//      BackProcessor<IdContext> backProcessor;
+//      ThreadPoolTaskScheduler taskScheduler;
+//
+//      taskScheduler = new ThreadPoolTaskScheduler();
+//      taskScheduler.initialize();
+//      backRunner = new BackRunner<>();
+//      backProcessor = new BackProcessor<>() {
+//        @Override
+//        public boolean process(IdContext ctx) {
+//          long startId = ctx.getLastProcessedId() == null ? 0 : ctx.getLastProcessedId()+1;
+//          System.out.println("Processing " + ctx.getNumToProcess() + " ids starting from "
+//              + (startId == 0 ? "beginning " : startId) );
+//          String pageOfDataAsJson =
+//              tcService.fetchPageOfCandidateDataAsJson((int) startId);
+//          assertNotNull(pageOfDataAsJson);
+//
+//          Page<AnonCandidate>
+//              anonCandidates = null;
+//          try {
+//            anonCandidates = anonymizationService.anonymizePage(pageOfDataAsJson);
+//          } catch (JsonProcessingException e) {
+//            e.printStackTrace();
+//            throw new RuntimeException(e);
+//          }
+//          assertNotNull(anonCandidates);
+//          String collect = anonCandidates.stream()
+//              .map(ca -> Long.toString(ca.getCandidateNumber()))
+//              .collect(Collectors.joining(","));
+//          System.out.println("Received numbers: " + collect);
+//          long lastProcessed = startId + ctx.getNumToProcess() - 1;
+//          ctx.setLastProcessedId(lastProcessed);
+//          return lastProcessed+1 >= 50;
+//        }
+//      };
+//
+//      ScheduledFuture<?> scheduledFuture =
+//          backRunner.start(taskScheduler, backProcessor,
+//              new IdContext(null, 1),
+//              10);
+//
+//      Thread.sleep(30000);
+//
+//    } catch (Exception ex) {
+//      fail(ex);
+//    }
   }
 
 

--- a/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
@@ -93,7 +93,7 @@ class TalentCatalogServiceImplTest {
       tcService.login();
       assertTrue(tcService.isLoggedIn());
 
-      for (int i = 0; i < 10; i++) {
+      for (int i = 0; i < 3; i++) {
         IdentifiableCandidatePage pageOfIdentifiableCandidates = tcService
             .fetchPageOfIdentifiableCandidateData(i, 100);
         assertNotNull(pageOfIdentifiableCandidates);

--- a/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
@@ -59,7 +59,8 @@ class TalentCatalogServiceImplTest {
       tcService.login();
       assertTrue(tcService.isLoggedIn());
 
-      IdentifiableCandidatePage pageOfIdentifiableCandidates = tcService.fetchPageOfIdentifiableCandidateData(0);
+      IdentifiableCandidatePage pageOfIdentifiableCandidates = tcService
+          .fetchPageOfIdentifiableCandidateData(0, 100);
       assertNotNull(pageOfIdentifiableCandidates);
 
       List<CandidateDocument> anonCandidates = pageOfIdentifiableCandidates
@@ -93,7 +94,8 @@ class TalentCatalogServiceImplTest {
       assertTrue(tcService.isLoggedIn());
 
       for (int i = 0; i < 10; i++) {
-        IdentifiableCandidatePage pageOfIdentifiableCandidates = tcService.fetchPageOfIdentifiableCandidateData(i);
+        IdentifiableCandidatePage pageOfIdentifiableCandidates = tcService
+            .fetchPageOfIdentifiableCandidateData(i, 100);
         assertNotNull(pageOfIdentifiableCandidates);
 
         List<CandidateDocument> anonCandidates = pageOfIdentifiableCandidates

--- a/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
@@ -1,0 +1,144 @@
+package org.tctalent.anonymization.service;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.web.client.RestClientException;
+import org.tctalent.anonymization.model.AnonCandidate;
+import org.tctalent.server.repository.AnonCandidateRepository;
+import org.tctalent.util.background.BackProcessor;
+import org.tctalent.util.background.BackRunner;
+import org.tctalent.util.background.IdContext;
+
+@SpringBootTest
+class TalentCatalogServiceImplTest {
+  @Autowired
+  TalentCatalogServiceImpl tcService;
+
+  @Autowired
+  AnonymizationService anonymizationService;
+
+  @Autowired
+  AnonCandidateRepository anonCandidateRepository;
+
+  @BeforeEach
+  void setUp() {
+  }
+
+  @Test
+  void login() {
+    try {
+      tcService.login();
+      assertTrue(tcService.isLoggedIn());
+    } catch (RestClientException ex) {
+      fail(ex);
+    }
+  }
+
+  @Test
+  void fetchPageOfCandidateDataAsJson() {
+    try {
+      String pageOfDataAsJson = tcService.fetchPageOfCandidateDataAsJson(0);
+      assertNotNull(pageOfDataAsJson);
+    } catch (RestClientException ex) {
+      fail(ex);
+    }
+  }
+
+  @Test
+  void loginAndFetchPageOfCandidateDataAsJson() {
+    try {
+      tcService.login();
+      assertTrue(tcService.isLoggedIn());
+
+      String pageOfDataAsJson = tcService.fetchPageOfCandidateDataAsJson(0);
+      assertNotNull(pageOfDataAsJson);
+
+      Page<AnonCandidate>
+          anonCandidates = anonymizationService.anonymizePage(pageOfDataAsJson);
+      assertNotNull(anonCandidates);
+      String collect = anonCandidates.stream()
+          .map(ca -> Long.toString(ca.getCandidateNumber()))
+          .collect(Collectors.joining(","));
+      System.out.println("Received numbers: " + collect);
+
+      anonCandidateRepository.saveAll(anonCandidates);
+      for (AnonCandidate customer : anonCandidateRepository.findAll()) {
+        System.out.println(customer);
+      }
+
+
+    } catch (RestClientException ex) {
+      fail(ex);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void loginAndFetchFirstFewPagesOfCandidateData() {
+    try {
+      tcService.login();
+      assertTrue(tcService.isLoggedIn());
+
+      BackRunner<IdContext> backRunner;
+      BackProcessor<IdContext> backProcessor;
+      ThreadPoolTaskScheduler taskScheduler;
+
+      taskScheduler = new ThreadPoolTaskScheduler();
+      taskScheduler.initialize();
+      backRunner = new BackRunner<>();
+      backProcessor = new BackProcessor<>() {
+        @Override
+        public boolean process(IdContext ctx) {
+          long startId = ctx.getLastProcessedId() == null ? 0 : ctx.getLastProcessedId()+1;
+          System.out.println("Processing " + ctx.getNumToProcess() + " ids starting from "
+              + (startId == 0 ? "beginning " : startId) );
+          String pageOfDataAsJson =
+              tcService.fetchPageOfCandidateDataAsJson((int) startId);
+          assertNotNull(pageOfDataAsJson);
+
+          Page<AnonCandidate>
+              anonCandidates = null;
+          try {
+            anonCandidates = anonymizationService.anonymizePage(pageOfDataAsJson);
+          } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+          }
+          assertNotNull(anonCandidates);
+          String collect = anonCandidates.stream()
+              .map(ca -> Long.toString(ca.getCandidateNumber()))
+              .collect(Collectors.joining(","));
+          System.out.println("Received numbers: " + collect);
+          long lastProcessed = startId + ctx.getNumToProcess() - 1;
+          ctx.setLastProcessedId(lastProcessed);
+          return lastProcessed+1 >= 50;
+        }
+      };
+
+      ScheduledFuture<?> scheduledFuture =
+          backRunner.start(taskScheduler, backProcessor,
+              new IdContext(null, 1),
+              10);
+
+      Thread.sleep(30000);
+
+    } catch (Exception ex) {
+      fail(ex);
+    }
+  }
+
+
+
+}

--- a/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
@@ -4,36 +4,23 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
-import java.util.concurrent.ScheduledFuture;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
 import org.tctalent.anonymization.entity.mongo.CandidateDocument;
 import org.tctalent.anonymization.mapper.CandidateMapper;
-import org.tctalent.anonymization.model.Candidate;
-import org.tctalent.anonymization.model.CandidatePage;
-import org.tctalent.anonymization.model.IdentifiableCandidate;
 import org.tctalent.anonymization.model.IdentifiableCandidatePage;
 import org.tctalent.anonymization.repository.CandidateMongoRepository;
-import org.tctalent.util.background.BackProcessor;
-import org.tctalent.util.background.BackRunner;
-import org.tctalent.util.background.IdContext;
 
 @SpringBootTest
 class TalentCatalogServiceImplTest {
   @Autowired
   TalentCatalogServiceImpl tcService;
-
-  @Autowired
-  AnonymizationService anonymizationService;
 
   @Autowired
   CandidateMongoRepository anonCandidateRepository;
@@ -99,59 +86,40 @@ class TalentCatalogServiceImplTest {
   }
 
   @Test
+  @Transactional
   void loginAndFetchFirstFewPagesOfCandidateData() {
-//    try {
-//      tcService.login();
-//      assertTrue(tcService.isLoggedIn());
-//
-//      BackRunner<IdContext> backRunner;
-//      BackProcessor<IdContext> backProcessor;
-//      ThreadPoolTaskScheduler taskScheduler;
-//
-//      taskScheduler = new ThreadPoolTaskScheduler();
-//      taskScheduler.initialize();
-//      backRunner = new BackRunner<>();
-//      backProcessor = new BackProcessor<>() {
-//        @Override
-//        public boolean process(IdContext ctx) {
-//          long startId = ctx.getLastProcessedId() == null ? 0 : ctx.getLastProcessedId()+1;
-//          System.out.println("Processing " + ctx.getNumToProcess() + " ids starting from "
-//              + (startId == 0 ? "beginning " : startId) );
-//          String pageOfDataAsJson =
-//              tcService.fetchPageOfCandidateDataAsJson((int) startId);
-//          assertNotNull(pageOfDataAsJson);
-//
-//          Page<AnonCandidate>
-//              anonCandidates = null;
-//          try {
-//            anonCandidates = anonymizationService.anonymizePage(pageOfDataAsJson);
-//          } catch (JsonProcessingException e) {
-//            e.printStackTrace();
-//            throw new RuntimeException(e);
-//          }
-//          assertNotNull(anonCandidates);
-//          String collect = anonCandidates.stream()
-//              .map(ca -> Long.toString(ca.getCandidateNumber()))
-//              .collect(Collectors.joining(","));
-//          System.out.println("Received numbers: " + collect);
-//          long lastProcessed = startId + ctx.getNumToProcess() - 1;
-//          ctx.setLastProcessedId(lastProcessed);
-//          return lastProcessed+1 >= 50;
-//        }
-//      };
-//
-//      ScheduledFuture<?> scheduledFuture =
-//          backRunner.start(taskScheduler, backProcessor,
-//              new IdContext(null, 1),
-//              10);
-//
-//      Thread.sleep(30000);
-//
-//    } catch (Exception ex) {
-//      fail(ex);
-//    }
+    try {
+      tcService.login();
+      assertTrue(tcService.isLoggedIn());
+
+      for (int i = 0; i < 10; i++) {
+        IdentifiableCandidatePage pageOfIdentifiableCandidates = tcService.fetchPageOfIdentifiableCandidateData(i);
+        assertNotNull(pageOfIdentifiableCandidates);
+
+        List<CandidateDocument> anonCandidates = pageOfIdentifiableCandidates
+            .getContent()
+            .stream()
+            .map(candidateMapper::anonymize)
+            .toList();
+
+        assertNotNull(anonCandidates);
+        String collect = anonCandidates
+            .stream()
+            .map(ca -> ca.getUuid().toString())
+            .collect(Collectors.joining(","));
+        System.out.println("Received numbers: " + collect);
+
+        anonCandidateRepository.saveAll(anonCandidates);
+        for (CandidateDocument candidate : anonCandidateRepository.findAll()) {
+          System.out.println(candidate);
+        }
+
+        Thread.sleep(3000);
+      }
+
+    } catch (Exception ex) {
+      fail(ex);
+    }
   }
-
-
 
 }


### PR DESCRIPTION
This PR merges changes from #7 

- Updates batch processing to read candidates using the TC service (i.e. via Rest API)
- Adds unit tests for batch processing and related classes
