### PR TITLE
Candidate and partner public IDs and TC partner prefix (service)

### DIFF
--- a/src/main/java/org/tctalent/anonymization/controller/CandidateController.java
+++ b/src/main/java/org/tctalent/anonymization/controller/CandidateController.java
@@ -37,8 +37,8 @@ public class CandidateController implements V1Api {
    * {@inheritDoc}
    */
   @Override
-  public ResponseEntity<Candidate> getCandidateById(UUID candidateId) {
-    Candidate candidate = candidateService.findById(candidateId);
+  public ResponseEntity<Candidate> getCandidateByPublicId(UUID publicId) {
+    Candidate candidate = candidateService.findByPublicId(publicId);
     return ResponseEntity.ok(candidate);
   }
 

--- a/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateDocument.java
+++ b/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateDocument.java
@@ -166,18 +166,17 @@ public class CandidateDocument {
   private Country nationality;
   private Long numberDependants;
   private YesNoUnsure partnerRegistered;
+  private UUID partnerPublicId;
 
   @Valid
   private List<Long> partnerCitizenship;
   private EducationLevel partnerEduLevel;
-  private String partnerEduLevelNotes;
   private YesNo partnerEnglish;
   private LanguageLevel partnerEnglishLevel;
   private IeltsStatus partnerIelts;
   private String partnerIeltsScore;
   private Long partnerIeltsYr;
   private Occupation partnerOccupation;
-  private String partnerOccupationNotes;
   private ResidenceStatus residenceStatus;
   private String residenceStatusNotes;
   private YesNoUnsure returnedHome;
@@ -342,16 +341,15 @@ public class CandidateDocument {
     sb.append("    nationality: ").append(toIndentedString(nationality)).append("\n");
     sb.append("    numberDependants: ").append(toIndentedString(numberDependants)).append("\n");
     sb.append("    partnerRegistered: ").append(toIndentedString(partnerRegistered)).append("\n");
+    sb.append("    partnerPublicId: ").append(toIndentedString(partnerPublicId)).append("\n");
     sb.append("    partnerCitizenship: ").append(toIndentedString(partnerCitizenship)).append("\n");
     sb.append("    partnerEduLevel: ").append(toIndentedString(partnerEduLevel)).append("\n");
-    sb.append("    partnerEduLevelNotes: ").append(toIndentedString(partnerEduLevelNotes)).append("\n");
     sb.append("    partnerEnglish: ").append(toIndentedString(partnerEnglish)).append("\n");
     sb.append("    partnerEnglishLevel: ").append(toIndentedString(partnerEnglishLevel)).append("\n");
     sb.append("    partnerIelts: ").append(toIndentedString(partnerIelts)).append("\n");
     sb.append("    partnerIeltsScore: ").append(toIndentedString(partnerIeltsScore)).append("\n");
     sb.append("    partnerIeltsYr: ").append(toIndentedString(partnerIeltsYr)).append("\n");
     sb.append("    partnerOccupation: ").append(toIndentedString(partnerOccupation)).append("\n");
-    sb.append("    partnerOccupationNotes: ").append(toIndentedString(partnerOccupationNotes)).append("\n");
     sb.append("    residenceStatus: ").append(toIndentedString(residenceStatus)).append("\n");
     sb.append("    residenceStatusNotes: ").append(toIndentedString(residenceStatusNotes)).append("\n");
     sb.append("    returnedHome: ").append(toIndentedString(returnedHome)).append("\n");

--- a/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateDocument.java
+++ b/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateDocument.java
@@ -31,7 +31,7 @@ import org.tctalent.anonymization.entity.common.enums.AvailImmediateReason;
 @Document(collection = "candidates")
 public class CandidateDocument {
 
-  private UUID uuid;
+  private UUID publicId;
 
   private String candidateNumber;
   private String additionalInfo;
@@ -230,8 +230,8 @@ public class CandidateDocument {
 
   @Override
   public int hashCode() {
-    if (uuid != null) {
-      return uuid.hashCode();
+    if (publicId != null) {
+      return publicId.hashCode();
     } else {
       return super.hashCode();
     }
@@ -247,17 +247,17 @@ public class CandidateDocument {
     CandidateDocument other = (CandidateDocument) obj;
 
     //If id is missing assume that it is not equal to other instance.
-    if (uuid == null) return false;
+    if (publicId == null) return false;
 
     //Equivalence by id
-    return uuid.equals(other.uuid);
+    return publicId.equals(other.publicId);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class Candidate {\n");
-    sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
+    sb.append("    publicId: ").append(toIndentedString(publicId)).append("\n");
     sb.append("    additionalInfo: ").append(toIndentedString(additionalInfo)).append("\n");
     sb.append("    asylumYear: ").append(toIndentedString(asylumYear)).append("\n");
     sb.append("    arrestImprison: ").append(toIndentedString(arrestImprison)).append("\n");

--- a/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateDocument.java
+++ b/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateDocument.java
@@ -94,7 +94,7 @@ public class CandidateDocument {
   private String city;
   private YesNo conflict;
   private String conflictNotes;
-  private Boolean contactConsentPartners;
+  private Boolean contactConsentTcPartners;
   private Boolean contactConsentRegistration;
   private Country country;
   private YesNo covidVaccinated;
@@ -286,7 +286,7 @@ public class CandidateDocument {
     sb.append("    city: ").append(toIndentedString(city)).append("\n");
     sb.append("    conflict: ").append(toIndentedString(conflict)).append("\n");
     sb.append("    conflictNotes: ").append(toIndentedString(conflictNotes)).append("\n");
-    sb.append("    contactConsentPartners: ").append(toIndentedString(contactConsentPartners)).append("\n");
+    sb.append("    contactConsentTcPartners: ").append(toIndentedString(contactConsentTcPartners)).append("\n");
     sb.append("    contactConsentRegistration: ").append(toIndentedString(contactConsentRegistration)).append("\n");
     sb.append("    country: ").append(toIndentedString(country)).append("\n");
     sb.append("    covidVaccinated: ").append(toIndentedString(covidVaccinated)).append("\n");

--- a/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
@@ -37,7 +37,6 @@ public interface CandidateMapper {
    * @param entity the database candidate entity
    * @return the corresponding anonymised mongo document
    */
-  @Mapping(source = "id", target = "uuid") // todo sm this mocks a uuid based on the id - remove it when uuid's are sent from tc
   @Mapping(source = "createdDate", target = "createdDate")
   CandidateDocument anonymize(org.tctalent.anonymization.entity.db.Candidate entity);
 
@@ -48,6 +47,5 @@ public interface CandidateMapper {
    * @param model the identifiable candidate model
    * @return the corresponding anonymised mongo document
    */
-  @Mapping(source = "id", target = "uuid") // todo sm this mocks a uuid based on the id - remove it when uuid's are sent from tc
   CandidateDocument anonymize(IdentifiableCandidate model);
 }

--- a/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
@@ -48,5 +48,6 @@ public interface CandidateMapper {
    * @return the corresponding anonymised mongo document
    */
   @Mapping(source = "contactConsentPartners", target = "contactConsentTcPartners")
+  @Mapping(source = "partnerCandidate.publicId", target = "partnerPublicId")
   CandidateDocument anonymize(IdentifiableCandidate model);
 }

--- a/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
@@ -47,5 +47,6 @@ public interface CandidateMapper {
    * @param model the identifiable candidate model
    * @return the corresponding anonymised mongo document
    */
+  @Mapping(source = "contactConsentPartners", target = "contactConsentTcPartners")
   CandidateDocument anonymize(IdentifiableCandidate model);
 }

--- a/src/main/java/org/tctalent/anonymization/repository/CandidateMongoRepository.java
+++ b/src/main/java/org/tctalent/anonymization/repository/CandidateMongoRepository.java
@@ -8,5 +8,5 @@ import org.tctalent.anonymization.entity.mongo.CandidateDocument;
 
 @Repository
 public interface CandidateMongoRepository extends MongoRepository<CandidateDocument, String> {
-  Optional<CandidateDocument> findByUuid(UUID uuid);
+  Optional<CandidateDocument> findByPublicId(UUID publicId);
 }

--- a/src/main/java/org/tctalent/anonymization/service/CandidateService.java
+++ b/src/main/java/org/tctalent/anonymization/service/CandidateService.java
@@ -1,7 +1,6 @@
 package org.tctalent.anonymization.service;
 
 import java.util.UUID;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.tctalent.anonymization.model.Candidate;
 import org.tctalent.anonymization.model.CandidatePage;
@@ -10,5 +9,5 @@ public interface CandidateService {
 
   CandidatePage findAll(Pageable pageable);
 
-  Candidate findById(UUID id);
+  Candidate findByPublicId(UUID publicId);
 }

--- a/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
@@ -27,9 +27,9 @@ public class CandidateServiceImpl implements CandidateService {
   }
 
   @Override
-  public Candidate findById(UUID id) {
+  public Candidate findById(UUID publicId) {
     return candidateMongoRepository
-        .findByUuid(id)
+        .findByPublicId(publicId)
         .map(candidateMapper::toCandidateModel)
         .orElseThrow(() -> new RuntimeException("Candidate not found")); // todo better exceptions
   }

--- a/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
@@ -27,7 +27,7 @@ public class CandidateServiceImpl implements CandidateService {
   }
 
   @Override
-  public Candidate findById(UUID publicId) {
+  public Candidate findByPublicId(UUID publicId) {
     return candidateMongoRepository
         .findByPublicId(publicId)
         .map(candidateMapper::toCandidateModel)

--- a/src/test/java/org/tctalent/anonymization/controller/CandidateControllerTest.java
+++ b/src/test/java/org/tctalent/anonymization/controller/CandidateControllerTest.java
@@ -55,12 +55,12 @@ class CandidateControllerTest {
 
   @Test
   @Transactional
-  @DisplayName("Get candidate by Id")
-  void testGetCandidateById() throws Exception {
-    mockMvc.perform(get(CandidateController.BASE_URL + "/{candidateId}", testCandidate.getUuid())
+  @DisplayName("Get candidate by public Id")
+  void testGetCandidateByPublicId() throws Exception {
+    mockMvc.perform(get(CandidateController.BASE_URL + "/{publicId}", testCandidate.getPublicId())
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(testCandidate.getUuid().toString()));
+        .andExpect(jsonPath("$.publicId").value(testCandidate.getPublicId().toString()));
   }
 
 }

--- a/src/test/java/org/tctalent/anonymization/mapper/CandidateMapperTest.java
+++ b/src/test/java/org/tctalent/anonymization/mapper/CandidateMapperTest.java
@@ -4,18 +4,15 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
-import org.mapstruct.factory.Mappers;
 
-import java.util.Arrays;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 import org.tctalent.anonymization.entity.mongo.CandidateDocument;
 import org.tctalent.anonymization.model.IdentifiableCandidate;
+import org.tctalent.anonymization.model.IdentifiablePartner;
 
 @SpringBootTest
 public class CandidateMapperTest {
@@ -50,6 +47,24 @@ public class CandidateMapperTest {
 
     // Verify the mapping works for null input
     assertThat(result.getContactConsentTcPartners()).isNull();
+  }
+
+  @Test
+  void shouldMapPartnerCandidatePublicIdToPartnerPublicId() {
+    // Arrange
+    UUID partnerPublicId = UUID.randomUUID();
+    IdentifiableCandidate source = new IdentifiableCandidate();
+    IdentifiablePartner partnerCandidate = new IdentifiablePartner();
+    partnerCandidate.setPublicId(partnerPublicId);
+    source.setPartnerCandidate(partnerCandidate);
+
+    // Act
+    CandidateDocument result = mapper.anonymize(source);
+
+    // Assert
+    assertThat(result.getPartnerPublicId())
+        .isNotNull()
+        .isEqualTo(partnerPublicId);
   }
 
 }

--- a/src/test/java/org/tctalent/anonymization/mapper/CandidateMapperTest.java
+++ b/src/test/java/org/tctalent/anonymization/mapper/CandidateMapperTest.java
@@ -1,0 +1,55 @@
+package org.tctalent.anonymization.mapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.tctalent.anonymization.entity.mongo.CandidateDocument;
+import org.tctalent.anonymization.model.IdentifiableCandidate;
+
+@SpringBootTest
+public class CandidateMapperTest {
+
+  @Autowired
+  @Qualifier("candidateMapperImpl")
+  private CandidateMapper mapper;
+
+  @Test
+  void shouldMapContactConsentPartnersToContactConsentTcPartners() {
+    // Create an IdentifiableCandidate with test data
+    IdentifiableCandidate source = new IdentifiableCandidate();
+    source.setContactConsentPartners(true);
+
+    // Map the source object to a CandidateDocument
+    CandidateDocument result = mapper.anonymize(source);
+
+    // Verify that the field is correctly mapped
+    assertThat(result.getContactConsentTcPartners())
+        .isNotNull()
+        .isEqualTo(true);
+    }
+
+  @Test
+  void shouldHandleNullContactConsentPartners() {
+    // Create an IdentifiableCandidate with null data
+    IdentifiableCandidate source = new IdentifiableCandidate();
+    source.setContactConsentPartners(null);
+
+    // Map the source object to a CandidateDocument
+    CandidateDocument result = mapper.anonymize(source);
+
+    // Verify the mapping works for null input
+    assertThat(result.getContactConsentTcPartners()).isNull();
+  }
+
+}

--- a/src/test/java/org/tctalent/anonymization/service/AnonymizationServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/AnonymizationServiceImplTest.java
@@ -35,7 +35,7 @@ class AnonymizationServiceImplTest {
     @Test
     void anonymize() throws JsonProcessingException {
 
-        UUID uuid = UUID.randomUUID();
+        UUID publicId = UUID.randomUUID();
         String id = "123456";
 
         Country nationality = Country.builder()
@@ -46,7 +46,7 @@ class AnonymizationServiceImplTest {
 
         IdentifiableCandidate identifiableCandidate = IdentifiableCandidate.builder()
             .id(id)
-            .uuid(uuid)
+            .publicId(publicId)
             .phone("+1-234-567-890")
             .address1("123 Main St, Springfield, IL")
             .dob(LocalDate.parse("1985-06-15"))
@@ -56,7 +56,7 @@ class AnonymizationServiceImplTest {
 
         Candidate candidate = service.anonymize(identifiableCandidate);
 
-        assertEquals(uuid, candidate.getUuid());
+        assertEquals(publicId, candidate.getPublicId());
         System.out.println(candidate);
     }
 }

--- a/src/test/java/org/tctalent/anonymization/service/AnonymizationServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/AnonymizationServiceImplTest.java
@@ -15,7 +15,6 @@ import org.tctalent.anonymization.model.Candidate;
 import org.tctalent.anonymization.model.Country;
 import org.tctalent.anonymization.model.IdentifiableCandidate;
 import org.tctalent.anonymization.model.Status;
-import org.tctalent.anonymization.model.User;
 
 /**
  * Test
@@ -39,12 +38,6 @@ class AnonymizationServiceImplTest {
         UUID uuid = UUID.randomUUID();
         String id = "123456";
 
-        User user = User.builder()
-            .firstName("John")
-            .lastName("Doe")
-            .email("johndoe@example.com")
-            .build();
-
         Country nationality = Country.builder()
             .isoCode("GB")
             .name("United Kingdon")
@@ -54,7 +47,6 @@ class AnonymizationServiceImplTest {
         IdentifiableCandidate identifiableCandidate = IdentifiableCandidate.builder()
             .id(id)
             .uuid(uuid)
-            .user(user)
             .phone("+1-234-567-890")
             .address1("123 Main St, Springfield, IL")
             .dob(LocalDate.parse("1985-06-15"))

--- a/src/test/java/org/tctalent/anonymization/service/CandidateServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/CandidateServiceImplTest.java
@@ -64,19 +64,19 @@ class CandidateServiceImplTest {
   @Test
   @DisplayName("Test find candidate by id")
   void testFindById() {
-    UUID id = UUID.randomUUID();
+    UUID publicId = UUID.randomUUID();
     CandidateDocument candidateDocument = new CandidateDocument();
     Candidate candidate = new Candidate();
 
     when(candidateMongoRepository
-        .findByUuid(id))
+        .findByPublicId(publicId))
         .thenReturn(Optional.of(candidateDocument));
 
     when(candidateMapper
         .toCandidateModel(candidateDocument))
         .thenReturn(candidate);
 
-    Candidate result = candidateService.findById(id);
+    Candidate result = candidateService.findByPublicId(publicId);
 
     assertNotNull(result);
     assertEquals(candidate, result);
@@ -85,15 +85,15 @@ class CandidateServiceImplTest {
   @Test
   @DisplayName("Test find candidate by id not found")
   void testFindById_NotFound() {
-    UUID id = UUID.randomUUID();
+    UUID publicId = UUID.randomUUID();
 
     when(candidateMongoRepository
-        .findByUuid(id))
+        .findByPublicId(publicId))
         .thenReturn(Optional.empty());
 
     Exception exception = assertThrows(
         RuntimeException.class,
-        () -> candidateService.findById(id),
+        () -> candidateService.findByPublicId(publicId),
         "Should throw an exception if the candidate is not found"
     );
 

--- a/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
@@ -72,7 +72,7 @@ class TalentCatalogServiceImplTest {
       assertNotNull(anonCandidates);
       String collect = anonCandidates
           .stream()
-          .map(ca -> ca.getUuid().toString())
+          .map(ca -> ca.getPublicId().toString())
           .collect(Collectors.joining(","));
       System.out.println("Received numbers: " + collect);
 
@@ -107,7 +107,7 @@ class TalentCatalogServiceImplTest {
         assertNotNull(anonCandidates);
         String collect = anonCandidates
             .stream()
-            .map(ca -> ca.getUuid().toString())
+            .map(ca -> ca.getPublicId().toString())
             .collect(Collectors.joining(","));
         System.out.println("Received numbers: " + collect);
 


### PR DESCRIPTION
This PR:

- updates the service mappings, endpoints and unit tests to use public IDs for candidates