### PR TITLE
1770 year of birth and eligibility prefix

### DIFF
--- a/src/main/java/org/tctalent/anonymization/controller/CandidateController.java
+++ b/src/main/java/org/tctalent/anonymization/controller/CandidateController.java
@@ -37,8 +37,8 @@ public class CandidateController implements V1Api {
    * {@inheritDoc}
    */
   @Override
-  public ResponseEntity<Candidate> getCandidateById(UUID candidateId) {
-    Candidate candidate = candidateService.findById(candidateId);
+  public ResponseEntity<Candidate> getCandidateByPublicId(UUID publicId) {
+    Candidate candidate = candidateService.findByPublicId(publicId);
     return ResponseEntity.ok(candidate);
   }
 

--- a/src/main/java/org/tctalent/anonymization/entity/common/enums/TcEligibilityAssessment.java
+++ b/src/main/java/org/tctalent/anonymization/entity/common/enums/TcEligibilityAssessment.java
@@ -16,7 +16,7 @@
 
 package org.tctalent.anonymization.entity.common.enums;
 
-public enum TBBEligibilityAssessment {
+public enum TcEligibilityAssessment {
     NoResponse,
     Proceed,
     Discuss,

--- a/src/main/java/org/tctalent/anonymization/entity/db/CandidateVisaJobCheckBase.java
+++ b/src/main/java/org/tctalent/anonymization/entity/db/CandidateVisaJobCheckBase.java
@@ -27,7 +27,7 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.tctalent.anonymization.entity.common.enums.OtherVisas;
-import org.tctalent.anonymization.entity.common.enums.TBBEligibilityAssessment;
+import org.tctalent.anonymization.entity.common.enums.TcEligibilityAssessment;
 import org.tctalent.anonymization.entity.common.enums.VisaEligibility;
 import org.tctalent.anonymization.entity.common.enums.YesNo;
 
@@ -88,7 +88,7 @@ public class CandidateVisaJobCheckBase extends AbstractDomainObject<Long> {
     private VisaEligibility putForward;
 
     @Enumerated(EnumType.STRING)
-    private TBBEligibilityAssessment tbbEligibility;
+    private TcEligibilityAssessment tbbEligibility;
 
     private String notes;
 

--- a/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateDocument.java
+++ b/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateDocument.java
@@ -166,18 +166,17 @@ public class CandidateDocument {
   private Country nationality;
   private Long numberDependants;
   private YesNoUnsure partnerRegistered;
+  private UUID partnerPublicId;
 
   @Valid
   private List<Long> partnerCitizenship;
   private EducationLevel partnerEduLevel;
-  private String partnerEduLevelNotes;
   private YesNo partnerEnglish;
   private LanguageLevel partnerEnglishLevel;
   private IeltsStatus partnerIelts;
   private String partnerIeltsScore;
   private Long partnerIeltsYr;
   private Occupation partnerOccupation;
-  private String partnerOccupationNotes;
   private ResidenceStatus residenceStatus;
   private String residenceStatusNotes;
   private YesNoUnsure returnedHome;
@@ -342,16 +341,15 @@ public class CandidateDocument {
     sb.append("    nationality: ").append(toIndentedString(nationality)).append("\n");
     sb.append("    numberDependants: ").append(toIndentedString(numberDependants)).append("\n");
     sb.append("    partnerRegistered: ").append(toIndentedString(partnerRegistered)).append("\n");
+    sb.append("    partnerPublicId: ").append(toIndentedString(partnerPublicId)).append("\n");
     sb.append("    partnerCitizenship: ").append(toIndentedString(partnerCitizenship)).append("\n");
     sb.append("    partnerEduLevel: ").append(toIndentedString(partnerEduLevel)).append("\n");
-    sb.append("    partnerEduLevelNotes: ").append(toIndentedString(partnerEduLevelNotes)).append("\n");
     sb.append("    partnerEnglish: ").append(toIndentedString(partnerEnglish)).append("\n");
     sb.append("    partnerEnglishLevel: ").append(toIndentedString(partnerEnglishLevel)).append("\n");
     sb.append("    partnerIelts: ").append(toIndentedString(partnerIelts)).append("\n");
     sb.append("    partnerIeltsScore: ").append(toIndentedString(partnerIeltsScore)).append("\n");
     sb.append("    partnerIeltsYr: ").append(toIndentedString(partnerIeltsYr)).append("\n");
     sb.append("    partnerOccupation: ").append(toIndentedString(partnerOccupation)).append("\n");
-    sb.append("    partnerOccupationNotes: ").append(toIndentedString(partnerOccupationNotes)).append("\n");
     sb.append("    residenceStatus: ").append(toIndentedString(residenceStatus)).append("\n");
     sb.append("    residenceStatusNotes: ").append(toIndentedString(residenceStatusNotes)).append("\n");
     sb.append("    returnedHome: ").append(toIndentedString(returnedHome)).append("\n");

--- a/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateDocument.java
+++ b/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateDocument.java
@@ -31,7 +31,7 @@ import org.tctalent.anonymization.entity.common.enums.AvailImmediateReason;
 @Document(collection = "candidates")
 public class CandidateDocument {
 
-  private UUID uuid;
+  private UUID publicId;
 
   private String candidateNumber;
   private String additionalInfo;
@@ -230,8 +230,8 @@ public class CandidateDocument {
 
   @Override
   public int hashCode() {
-    if (uuid != null) {
-      return uuid.hashCode();
+    if (publicId != null) {
+      return publicId.hashCode();
     } else {
       return super.hashCode();
     }
@@ -247,17 +247,17 @@ public class CandidateDocument {
     CandidateDocument other = (CandidateDocument) obj;
 
     //If id is missing assume that it is not equal to other instance.
-    if (uuid == null) return false;
+    if (publicId == null) return false;
 
     //Equivalence by id
-    return uuid.equals(other.uuid);
+    return publicId.equals(other.publicId);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class Candidate {\n");
-    sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
+    sb.append("    publicId: ").append(toIndentedString(publicId)).append("\n");
     sb.append("    additionalInfo: ").append(toIndentedString(additionalInfo)).append("\n");
     sb.append("    asylumYear: ").append(toIndentedString(asylumYear)).append("\n");
     sb.append("    arrestImprison: ").append(toIndentedString(arrestImprison)).append("\n");

--- a/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateDocument.java
+++ b/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateDocument.java
@@ -94,7 +94,7 @@ public class CandidateDocument {
   private String city;
   private YesNo conflict;
   private String conflictNotes;
-  private Boolean contactConsentPartners;
+  private Boolean contactConsentTcPartners;
   private Boolean contactConsentRegistration;
   private Country country;
   private YesNo covidVaccinated;
@@ -286,7 +286,7 @@ public class CandidateDocument {
     sb.append("    city: ").append(toIndentedString(city)).append("\n");
     sb.append("    conflict: ").append(toIndentedString(conflict)).append("\n");
     sb.append("    conflictNotes: ").append(toIndentedString(conflictNotes)).append("\n");
-    sb.append("    contactConsentPartners: ").append(toIndentedString(contactConsentPartners)).append("\n");
+    sb.append("    contactConsentTcPartners: ").append(toIndentedString(contactConsentTcPartners)).append("\n");
     sb.append("    contactConsentRegistration: ").append(toIndentedString(contactConsentRegistration)).append("\n");
     sb.append("    country: ").append(toIndentedString(country)).append("\n");
     sb.append("    covidVaccinated: ").append(toIndentedString(covidVaccinated)).append("\n");

--- a/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateVisaJobCheck.java
+++ b/src/main/java/org/tctalent/anonymization/entity/mongo/CandidateVisaJobCheck.java
@@ -5,7 +5,7 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.tctalent.anonymization.entity.common.enums.OtherVisas;
-import org.tctalent.anonymization.entity.common.enums.TBBEligibilityAssessment;
+import org.tctalent.anonymization.entity.common.enums.TcEligibilityAssessment;
 import org.tctalent.anonymization.entity.common.enums.VisaEligibility;
 import org.tctalent.anonymization.entity.common.enums.YesNo;
 
@@ -28,7 +28,7 @@ public class CandidateVisaJobCheck {
   private OtherVisas eligibleOther;
   private String eligibleOtherNotes;
   private VisaEligibility putForward;
-  private TBBEligibilityAssessment tbbEligibility;
+  private TcEligibilityAssessment tcEligibility;
   private String notes;
   private String relevantWorkExp;
   private String ageRequirement;
@@ -64,7 +64,7 @@ public class CandidateVisaJobCheck {
     sb.append("    eligibleOther: ").append(toIndentedString(eligibleOther)).append("\n");
     sb.append("    eligibleOtherNotes: ").append(toIndentedString(eligibleOtherNotes)).append("\n");
     sb.append("    putForward: ").append(toIndentedString(putForward)).append("\n");
-    sb.append("    tbbEligibility: ").append(toIndentedString(tbbEligibility)).append("\n");
+    sb.append("    tcEligibility: ").append(toIndentedString(tcEligibility)).append("\n");
     sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
     sb.append("    relevantWorkExp: ").append(toIndentedString(relevantWorkExp)).append("\n");
     sb.append("    ageRequirement: ").append(toIndentedString(ageRequirement)).append("\n");

--- a/src/main/java/org/tctalent/anonymization/entity/mongo/Dependant.java
+++ b/src/main/java/org/tctalent/anonymization/entity/mongo/Dependant.java
@@ -1,9 +1,7 @@
 package org.tctalent.anonymization.entity.mongo;
 
-import java.time.LocalDate;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.tctalent.anonymization.entity.common.enums.Gender;
 import org.tctalent.anonymization.entity.common.enums.Registration;
 import org.tctalent.anonymization.entity.common.enums.YesNo;
@@ -14,14 +12,10 @@ import org.tctalent.anonymization.entity.common.enums.DependantRelations;
 public class Dependant {
   private DependantRelations relation;
   private String relationOther;
-
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-  private LocalDate dob;
+  private Integer yearOfBirth;
   private Gender gender;
   private Registration registered;
-  private String registeredNotes;
   private YesNo healthConcern;
-  private String healthNotes;
 
   @Override
   public String toString() {
@@ -29,12 +23,10 @@ public class Dependant {
     sb.append("class Dependant {\n");
     sb.append("    relation: ").append(toIndentedString(relation)).append("\n");
     sb.append("    relationOther: ").append(toIndentedString(relationOther)).append("\n");
-    sb.append("    dob: ").append(toIndentedString(dob)).append("\n");
+    sb.append("    yearOfBirth: ").append(toIndentedString(yearOfBirth)).append("\n");
     sb.append("    gender: ").append(toIndentedString(gender)).append("\n");
     sb.append("    registered: ").append(toIndentedString(registered)).append("\n");
-    sb.append("    registeredNotes: ").append(toIndentedString(registeredNotes)).append("\n");
     sb.append("    healthConcern: ").append(toIndentedString(healthConcern)).append("\n");
-    sb.append("    healthNotes: ").append(toIndentedString(healthNotes)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
@@ -37,7 +37,6 @@ public interface CandidateMapper {
    * @param entity the database candidate entity
    * @return the corresponding anonymised mongo document
    */
-  @Mapping(source = "id", target = "uuid") // todo sm this mocks a uuid based on the id - remove it when uuid's are sent from tc
   @Mapping(source = "createdDate", target = "createdDate")
   CandidateDocument anonymize(org.tctalent.anonymization.entity.db.Candidate entity);
 
@@ -48,6 +47,5 @@ public interface CandidateMapper {
    * @param model the identifiable candidate model
    * @return the corresponding anonymised mongo document
    */
-  @Mapping(source = "id", target = "uuid") // todo sm this mocks a uuid based on the id - remove it when uuid's are sent from tc
   CandidateDocument anonymize(IdentifiableCandidate model);
 }

--- a/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
@@ -1,16 +1,16 @@
 package org.tctalent.anonymization.mapper;
 
 import java.time.LocalDate;
-import java.util.Calendar;
-import java.util.Date;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.springframework.data.domain.Page;
+import org.tctalent.anonymization.entity.mongo.Dependant;
 import org.tctalent.anonymization.model.Candidate;
 import org.tctalent.anonymization.model.CandidatePage;
 import org.tctalent.anonymization.model.IdentifiableCandidate;
 import org.tctalent.anonymization.entity.mongo.CandidateDocument;
+import org.tctalent.anonymization.model.IdentifiableDependant;
 
 @Mapper(uses = {
     IdMapper.class,
@@ -56,9 +56,11 @@ public interface CandidateMapper {
   @Mapping(source = "dob", target = "yearOfBirth", qualifiedByName = "extractYearFromLocalDate")
   CandidateDocument anonymize(IdentifiableCandidate model);
 
+  @Mapping(source = "dob", target = "yearOfBirth", qualifiedByName = "extractYearFromLocalDate")
+  Dependant mapDependant(IdentifiableDependant identifiableDependant);
+
   @Named("extractYearFromLocalDate")
   default Integer extractYearFromLocalDate(LocalDate dob) {
-    // todo confirm exception handling - try/catch - yes?
     return dob != null ? dob.getYear() : null;
   }
 

--- a/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
@@ -48,5 +48,6 @@ public interface CandidateMapper {
    * @return the corresponding anonymised mongo document
    */
   @Mapping(source = "contactConsentPartners", target = "contactConsentTcPartners")
+  @Mapping(source = "partnerCandidate.publicId", target = "partnerPublicId")
   CandidateDocument anonymize(IdentifiableCandidate model);
 }

--- a/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
@@ -47,5 +47,6 @@ public interface CandidateMapper {
    * @param model the identifiable candidate model
    * @return the corresponding anonymised mongo document
    */
+  @Mapping(source = "contactConsentPartners", target = "contactConsentTcPartners")
   CandidateDocument anonymize(IdentifiableCandidate model);
 }

--- a/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
@@ -1,7 +1,11 @@
 package org.tctalent.anonymization.mapper;
 
+import java.time.LocalDate;
+import java.util.Calendar;
+import java.util.Date;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.springframework.data.domain.Page;
 import org.tctalent.anonymization.model.Candidate;
 import org.tctalent.anonymization.model.CandidatePage;
@@ -49,5 +53,13 @@ public interface CandidateMapper {
    */
   @Mapping(source = "contactConsentPartners", target = "contactConsentTcPartners")
   @Mapping(source = "partnerCandidate.publicId", target = "partnerPublicId")
+  @Mapping(source = "dob", target = "yearOfBirth", qualifiedByName = "extractYearFromLocalDate")
   CandidateDocument anonymize(IdentifiableCandidate model);
+
+  @Named("extractYearFromLocalDate")
+  default Integer extractYearFromLocalDate(LocalDate dob) {
+    // todo confirm exception handling - try/catch - yes?
+    return dob != null ? dob.getYear() : null;
+  }
+
 }

--- a/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/CandidateMapper.java
@@ -5,11 +5,13 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.springframework.data.domain.Page;
+import org.tctalent.anonymization.entity.mongo.CandidateVisaJobCheck;
 import org.tctalent.anonymization.entity.mongo.Dependant;
 import org.tctalent.anonymization.model.Candidate;
 import org.tctalent.anonymization.model.CandidatePage;
 import org.tctalent.anonymization.model.IdentifiableCandidate;
 import org.tctalent.anonymization.entity.mongo.CandidateDocument;
+import org.tctalent.anonymization.model.IdentifiableCandidateVisaJobCheck;
 import org.tctalent.anonymization.model.IdentifiableDependant;
 
 @Mapper(uses = {
@@ -58,6 +60,9 @@ public interface CandidateMapper {
 
   @Mapping(source = "dob", target = "yearOfBirth", qualifiedByName = "extractYearFromLocalDate")
   Dependant mapDependant(IdentifiableDependant identifiableDependant);
+
+  @Mapping(source = "tbbEligibility", target = "tcEligibility")
+  CandidateVisaJobCheck mapVisaJobCheck(IdentifiableCandidateVisaJobCheck identifiableDependant);
 
   @Named("extractYearFromLocalDate")
   default Integer extractYearFromLocalDate(LocalDate dob) {

--- a/src/main/java/org/tctalent/anonymization/repository/CandidateMongoRepository.java
+++ b/src/main/java/org/tctalent/anonymization/repository/CandidateMongoRepository.java
@@ -8,5 +8,5 @@ import org.tctalent.anonymization.entity.mongo.CandidateDocument;
 
 @Repository
 public interface CandidateMongoRepository extends MongoRepository<CandidateDocument, String> {
-  Optional<CandidateDocument> findByUuid(UUID uuid);
+  Optional<CandidateDocument> findByPublicId(UUID publicId);
 }

--- a/src/main/java/org/tctalent/anonymization/request/candidate/visa/CandidateVisaCheckData.java
+++ b/src/main/java/org/tctalent/anonymization/request/candidate/visa/CandidateVisaCheckData.java
@@ -24,7 +24,7 @@ import org.tctalent.anonymization.entity.common.enums.DocumentStatus;
 import org.tctalent.anonymization.entity.common.enums.FamilyRelations;
 import org.tctalent.anonymization.entity.common.enums.OtherVisas;
 import org.tctalent.anonymization.entity.common.enums.RiskLevel;
-import org.tctalent.anonymization.entity.common.enums.TBBEligibilityAssessment;
+import org.tctalent.anonymization.entity.common.enums.TcEligibilityAssessment;
 import org.tctalent.anonymization.entity.common.enums.VisaEligibility;
 import org.tctalent.anonymization.entity.common.enums.YesNo;
 import org.tctalent.anonymization.entity.common.enums.YesNoUnsure;
@@ -78,7 +78,7 @@ public class CandidateVisaCheckData {
     private OtherVisas visaJobEligibleOther;
     private String visaJobEligibleOtherNotes;
     private VisaEligibility visaJobPutForward;
-    private TBBEligibilityAssessment visaJobTbbEligibility;
+    private TcEligibilityAssessment visaJobTbbEligibility;
     private String visaJobNotes;
     private String visaJobRelevantWorkExp;
     private String visaJobAgeRequirement;

--- a/src/main/java/org/tctalent/anonymization/service/CandidateService.java
+++ b/src/main/java/org/tctalent/anonymization/service/CandidateService.java
@@ -1,7 +1,6 @@
 package org.tctalent.anonymization.service;
 
 import java.util.UUID;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.tctalent.anonymization.model.Candidate;
 import org.tctalent.anonymization.model.CandidatePage;
@@ -10,5 +9,5 @@ public interface CandidateService {
 
   CandidatePage findAll(Pageable pageable);
 
-  Candidate findById(UUID id);
+  Candidate findByPublicId(UUID publicId);
 }

--- a/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
@@ -27,9 +27,9 @@ public class CandidateServiceImpl implements CandidateService {
   }
 
   @Override
-  public Candidate findById(UUID id) {
+  public Candidate findById(UUID publicId) {
     return candidateMongoRepository
-        .findByUuid(id)
+        .findByPublicId(publicId)
         .map(candidateMapper::toCandidateModel)
         .orElseThrow(() -> new RuntimeException("Candidate not found")); // todo better exceptions
   }

--- a/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
@@ -27,7 +27,7 @@ public class CandidateServiceImpl implements CandidateService {
   }
 
   @Override
-  public Candidate findById(UUID publicId) {
+  public Candidate findByPublicId(UUID publicId) {
     return candidateMongoRepository
         .findByPublicId(publicId)
         .map(candidateMapper::toCandidateModel)

--- a/src/test/java/org/tctalent/anonymization/controller/CandidateControllerTest.java
+++ b/src/test/java/org/tctalent/anonymization/controller/CandidateControllerTest.java
@@ -55,12 +55,12 @@ class CandidateControllerTest {
 
   @Test
   @Transactional
-  @DisplayName("Get candidate by Id")
-  void testGetCandidateById() throws Exception {
-    mockMvc.perform(get(CandidateController.BASE_URL + "/{candidateId}", testCandidate.getUuid())
+  @DisplayName("Get candidate by public Id")
+  void testGetCandidateByPublicId() throws Exception {
+    mockMvc.perform(get(CandidateController.BASE_URL + "/{publicId}", testCandidate.getPublicId())
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(testCandidate.getUuid().toString()));
+        .andExpect(jsonPath("$.publicId").value(testCandidate.getPublicId().toString()));
   }
 
 }

--- a/src/test/java/org/tctalent/anonymization/mapper/CandidateMapperTest.java
+++ b/src/test/java/org/tctalent/anonymization/mapper/CandidateMapperTest.java
@@ -4,18 +4,15 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
-import org.mapstruct.factory.Mappers;
 
-import java.util.Arrays;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 import org.tctalent.anonymization.entity.mongo.CandidateDocument;
 import org.tctalent.anonymization.model.IdentifiableCandidate;
+import org.tctalent.anonymization.model.IdentifiablePartner;
 
 @SpringBootTest
 public class CandidateMapperTest {
@@ -50,6 +47,24 @@ public class CandidateMapperTest {
 
     // Verify the mapping works for null input
     assertThat(result.getContactConsentTcPartners()).isNull();
+  }
+
+  @Test
+  void shouldMapPartnerCandidatePublicIdToPartnerPublicId() {
+    // Arrange
+    UUID partnerPublicId = UUID.randomUUID();
+    IdentifiableCandidate source = new IdentifiableCandidate();
+    IdentifiablePartner partnerCandidate = new IdentifiablePartner();
+    partnerCandidate.setPublicId(partnerPublicId);
+    source.setPartnerCandidate(partnerCandidate);
+
+    // Act
+    CandidateDocument result = mapper.anonymize(source);
+
+    // Assert
+    assertThat(result.getPartnerPublicId())
+        .isNotNull()
+        .isEqualTo(partnerPublicId);
   }
 
 }

--- a/src/test/java/org/tctalent/anonymization/mapper/CandidateMapperTest.java
+++ b/src/test/java/org/tctalent/anonymization/mapper/CandidateMapperTest.java
@@ -1,0 +1,55 @@
+package org.tctalent.anonymization.mapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.tctalent.anonymization.entity.mongo.CandidateDocument;
+import org.tctalent.anonymization.model.IdentifiableCandidate;
+
+@SpringBootTest
+public class CandidateMapperTest {
+
+  @Autowired
+  @Qualifier("candidateMapperImpl")
+  private CandidateMapper mapper;
+
+  @Test
+  void shouldMapContactConsentPartnersToContactConsentTcPartners() {
+    // Create an IdentifiableCandidate with test data
+    IdentifiableCandidate source = new IdentifiableCandidate();
+    source.setContactConsentPartners(true);
+
+    // Map the source object to a CandidateDocument
+    CandidateDocument result = mapper.anonymize(source);
+
+    // Verify that the field is correctly mapped
+    assertThat(result.getContactConsentTcPartners())
+        .isNotNull()
+        .isEqualTo(true);
+    }
+
+  @Test
+  void shouldHandleNullContactConsentPartners() {
+    // Create an IdentifiableCandidate with null data
+    IdentifiableCandidate source = new IdentifiableCandidate();
+    source.setContactConsentPartners(null);
+
+    // Map the source object to a CandidateDocument
+    CandidateDocument result = mapper.anonymize(source);
+
+    // Verify the mapping works for null input
+    assertThat(result.getContactConsentTcPartners()).isNull();
+  }
+
+}

--- a/src/test/java/org/tctalent/anonymization/mapper/CandidateMapperTest.java
+++ b/src/test/java/org/tctalent/anonymization/mapper/CandidateMapperTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
@@ -65,6 +66,34 @@ public class CandidateMapperTest {
     assertThat(result.getPartnerPublicId())
         .isNotNull()
         .isEqualTo(partnerPublicId);
+  }
+
+  @Test
+  void shouldMapDobToYearOfBirth() {
+    // Arrange
+    IdentifiableCandidate source = new IdentifiableCandidate();
+    source.setDob(LocalDate.of(1985, 6, 15));
+
+    // Act
+    CandidateDocument result = mapper.anonymize(source);
+
+    // Assert
+    assertThat(result.getYearOfBirth())
+        .isNotNull()
+        .isEqualTo(1985);
+  }
+
+  @Test
+  void shouldHandleNullDob() {
+    // Arrange
+    IdentifiableCandidate source = new IdentifiableCandidate();
+    source.setDob(null);
+
+    // Act
+    CandidateDocument result = mapper.anonymize(source);
+
+    // Assert
+    assertThat(result.getYearOfBirth()).isNull();
   }
 
 }

--- a/src/test/java/org/tctalent/anonymization/mapper/CandidateMapperTest.java
+++ b/src/test/java/org/tctalent/anonymization/mapper/CandidateMapperTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
@@ -12,8 +13,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.tctalent.anonymization.entity.mongo.CandidateDocument;
+import org.tctalent.anonymization.entity.mongo.Dependant;
+import org.tctalent.anonymization.model.DependantRelations;
+import org.tctalent.anonymization.model.Gender;
 import org.tctalent.anonymization.model.IdentifiableCandidate;
+import org.tctalent.anonymization.model.IdentifiableDependant;
 import org.tctalent.anonymization.model.IdentifiablePartner;
+import org.tctalent.anonymization.model.Registration;
+import org.tctalent.anonymization.model.YesNo;
 
 @SpringBootTest
 public class CandidateMapperTest {
@@ -94,6 +101,80 @@ public class CandidateMapperTest {
 
     // Assert
     assertThat(result.getYearOfBirth()).isNull();
+  }
+
+  @Test
+  void shouldMapCandidateDependantsIncludingYearOfBirth() {
+    // Arrange
+    IdentifiableDependant dependant1 = new IdentifiableDependant();
+    dependant1.setDob(LocalDate.of(2005, 3, 10));
+    dependant1.setRelation(DependantRelations.Child);
+    dependant1.setGender(Gender.male);
+    dependant1.setRegistered(Registration.UNHCR);
+    dependant1.setHealthConcern(YesNo.No);
+
+    IdentifiableDependant dependant2 = new IdentifiableDependant();
+    dependant2.setDob(LocalDate.of(2010, 7, 20));
+    dependant2.setRelation(DependantRelations.Child);
+    dependant2.setGender(Gender.female);
+    dependant2.setRegistered(Registration.NA);
+    dependant2.setHealthConcern(YesNo.Yes);
+
+    IdentifiableCandidate source = new IdentifiableCandidate();
+    source.setCandidateDependants(List.of(dependant1, dependant2));
+
+    // Act
+    CandidateDocument result = mapper.anonymize(source);
+
+    // Assert
+    assertThat(result.getCandidateDependants()).hasSize(2);
+
+    Dependant mappedDependant1 = result.getCandidateDependants().get(0);
+    assertThat(mappedDependant1.getYearOfBirth()).isEqualTo(2005);
+    assertThat(mappedDependant1.getRelation().name()).isSameAs(DependantRelations.Child.name());
+    assertThat(mappedDependant1.getGender().name()).isEqualTo(Gender.male.name());
+    assertThat(mappedDependant1.getRegistered().name()).isEqualTo(Registration.UNHCR.name());
+    assertThat(mappedDependant1.getHealthConcern().name()).isEqualTo(YesNo.No.name());
+
+    Dependant mappedDependant2 = result.getCandidateDependants().get(1);
+    assertThat(mappedDependant2.getYearOfBirth()).isEqualTo(2010);
+    assertThat(mappedDependant2.getRelation().name()).isEqualTo(DependantRelations.Child.name());
+    assertThat(mappedDependant2.getGender().name()).isEqualTo(Gender.female.name());
+    assertThat(mappedDependant2.getRegistered().name()).isEqualTo(Registration.NA.name());
+    assertThat(mappedDependant2.getHealthConcern().name()).isEqualTo(YesNo.Yes.name());
+  }
+
+  @Test
+  void shouldHandleNullCandidateDependants() {
+    // Arrange
+    IdentifiableCandidate source = new IdentifiableCandidate();
+    source.setCandidateDependants(null);
+
+    // Act
+    CandidateDocument result = mapper.anonymize(source);
+
+    // Assert
+    assertThat(result.getCandidateDependants()).isNull();
+  }
+
+  @Test
+  void shouldHandleNullDobInDependants() {
+    // Arrange
+    IdentifiableDependant dependant = new IdentifiableDependant();
+    dependant.setDob(null);
+    dependant.setRelation(DependantRelations.Child);
+
+    IdentifiableCandidate source = new IdentifiableCandidate();
+    source.setCandidateDependants(List.of(dependant));
+
+    // Act
+    CandidateDocument result = mapper.anonymize(source);
+
+    // Assert
+    assertThat(result.getCandidateDependants()).hasSize(1);
+    Dependant mappedDependant = result.getCandidateDependants().get(0);
+    assertThat(mappedDependant.getYearOfBirth()).isNull();
+    assertThat(mappedDependant.getRelation().name()).isEqualTo(DependantRelations.Child.name());
   }
 
 }

--- a/src/test/java/org/tctalent/anonymization/service/AnonymizationServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/AnonymizationServiceImplTest.java
@@ -35,7 +35,7 @@ class AnonymizationServiceImplTest {
     @Test
     void anonymize() throws JsonProcessingException {
 
-        UUID uuid = UUID.randomUUID();
+        UUID publicId = UUID.randomUUID();
         String id = "123456";
 
         Country nationality = Country.builder()
@@ -46,7 +46,7 @@ class AnonymizationServiceImplTest {
 
         IdentifiableCandidate identifiableCandidate = IdentifiableCandidate.builder()
             .id(id)
-            .uuid(uuid)
+            .publicId(publicId)
             .phone("+1-234-567-890")
             .address1("123 Main St, Springfield, IL")
             .dob(LocalDate.parse("1985-06-15"))
@@ -56,7 +56,7 @@ class AnonymizationServiceImplTest {
 
         Candidate candidate = service.anonymize(identifiableCandidate);
 
-        assertEquals(uuid, candidate.getUuid());
+        assertEquals(publicId, candidate.getPublicId());
         System.out.println(candidate);
     }
 }

--- a/src/test/java/org/tctalent/anonymization/service/AnonymizationServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/AnonymizationServiceImplTest.java
@@ -15,7 +15,6 @@ import org.tctalent.anonymization.model.Candidate;
 import org.tctalent.anonymization.model.Country;
 import org.tctalent.anonymization.model.IdentifiableCandidate;
 import org.tctalent.anonymization.model.Status;
-import org.tctalent.anonymization.model.User;
 
 /**
  * Test
@@ -39,12 +38,6 @@ class AnonymizationServiceImplTest {
         UUID uuid = UUID.randomUUID();
         String id = "123456";
 
-        User user = User.builder()
-            .firstName("John")
-            .lastName("Doe")
-            .email("johndoe@example.com")
-            .build();
-
         Country nationality = Country.builder()
             .isoCode("GB")
             .name("United Kingdon")
@@ -54,7 +47,6 @@ class AnonymizationServiceImplTest {
         IdentifiableCandidate identifiableCandidate = IdentifiableCandidate.builder()
             .id(id)
             .uuid(uuid)
-            .user(user)
             .phone("+1-234-567-890")
             .address1("123 Main St, Springfield, IL")
             .dob(LocalDate.parse("1985-06-15"))

--- a/src/test/java/org/tctalent/anonymization/service/CandidateServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/CandidateServiceImplTest.java
@@ -64,19 +64,19 @@ class CandidateServiceImplTest {
   @Test
   @DisplayName("Test find candidate by id")
   void testFindById() {
-    UUID id = UUID.randomUUID();
+    UUID publicId = UUID.randomUUID();
     CandidateDocument candidateDocument = new CandidateDocument();
     Candidate candidate = new Candidate();
 
     when(candidateMongoRepository
-        .findByUuid(id))
+        .findByPublicId(publicId))
         .thenReturn(Optional.of(candidateDocument));
 
     when(candidateMapper
         .toCandidateModel(candidateDocument))
         .thenReturn(candidate);
 
-    Candidate result = candidateService.findById(id);
+    Candidate result = candidateService.findByPublicId(publicId);
 
     assertNotNull(result);
     assertEquals(candidate, result);
@@ -85,15 +85,15 @@ class CandidateServiceImplTest {
   @Test
   @DisplayName("Test find candidate by id not found")
   void testFindById_NotFound() {
-    UUID id = UUID.randomUUID();
+    UUID publicId = UUID.randomUUID();
 
     when(candidateMongoRepository
-        .findByUuid(id))
+        .findByPublicId(publicId))
         .thenReturn(Optional.empty());
 
     Exception exception = assertThrows(
         RuntimeException.class,
-        () -> candidateService.findById(id),
+        () -> candidateService.findByPublicId(publicId),
         "Should throw an exception if the candidate is not found"
     );
 

--- a/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
@@ -72,7 +72,7 @@ class TalentCatalogServiceImplTest {
       assertNotNull(anonCandidates);
       String collect = anonCandidates
           .stream()
-          .map(ca -> ca.getUuid().toString())
+          .map(ca -> ca.getPublicId().toString())
           .collect(Collectors.joining(","));
       System.out.println("Received numbers: " + collect);
 
@@ -107,7 +107,7 @@ class TalentCatalogServiceImplTest {
         assertNotNull(anonCandidates);
         String collect = anonCandidates
             .stream()
-            .map(ca -> ca.getUuid().toString())
+            .map(ca -> ca.getPublicId().toString())
             .collect(Collectors.joining(","));
         System.out.println("Received numbers: " + collect);
 


### PR DESCRIPTION
This PR depends on and should be reviewed after PR #19 

- It sends yearOfBirth on the public api for candidates and dependants mapped from the corresponding dob,
- prefixes visa eligibility fields with "tc" instead of "tbb",
- includes unit tests for these mappings.

