### PR TITLE
map candidate survey type to how heard about us values

### DIFF
--- a/src/main/java/org/tctalent/anonymization/mapper/DocumentMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/DocumentMapper.java
@@ -1,10 +1,13 @@
 package org.tctalent.anonymization.mapper;
 
 import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.springframework.data.domain.Page;
+import org.tctalent.anonymization.domain.common.HowHeardAboutUs;
 import org.tctalent.anonymization.domain.document.CandidateVisaJobCheck;
 import org.tctalent.anonymization.domain.document.Dependant;
 import org.tctalent.anonymization.model.Candidate;
@@ -48,7 +51,7 @@ public interface DocumentMapper {
   @Mapping(source = "partnerCandidate.publicId", target = "partnerPublicId")
   @Mapping(source = "dob", target = "yearOfBirth", qualifiedByName = "extractYearFromLocalDate")
   @Mapping(target = "id", ignore = true)
-  @Mapping(source = "surveyType", target = "howHeardAboutUs",  qualifiedByName = "mapSurveyTypeToString")
+  @Mapping(source = "surveyType", target = "howHeardAboutUs", qualifiedByName = "mapSurveyTypeToHowHeardAboutUsString")
   CandidateDocument anonymize(IdentifiableCandidate model);
 
   @Mapping(source = "dob", target = "yearOfBirth", qualifiedByName = "extractYearFromLocalDate")
@@ -62,8 +65,42 @@ public interface DocumentMapper {
     return dob != null ? dob.getYear() : null;
   }
 
-  @Named("mapSurveyTypeToString")
-  default String mapSurveyTypeToString(SurveyType surveyType) {
-    return surveyType != null ? surveyType.getName() : null;
+  @Named("mapSurveyTypeToHowHeardAboutUsString")
+  default String mapSurveyTypeToHowHeardAboutUs(SurveyType surveyType) {
+    if (surveyType == null) {
+      return null;
+    }
+    String surveyTypeName = surveyType.getName();
+
+    final Map<String, String> SURVEY_TYPE_MAPPING = new HashMap<>();
+    SURVEY_TYPE_MAPPING.put("Online Google Search", HowHeardAboutUs.ONLINE_GOOGLE_SEARCH.name());
+    SURVEY_TYPE_MAPPING.put("Facebook", HowHeardAboutUs.FACEBOOK.name());
+    SURVEY_TYPE_MAPPING.put("Facebook - through an organisation", HowHeardAboutUs.FACEBOOK.name());
+    SURVEY_TYPE_MAPPING.put("Instagram", HowHeardAboutUs.INSTAGRAM.name());
+    SURVEY_TYPE_MAPPING.put("LinkedIn", HowHeardAboutUs.LINKEDIN.name());
+    SURVEY_TYPE_MAPPING.put("X", HowHeardAboutUs.X.name());
+    SURVEY_TYPE_MAPPING.put("WhatsApp", HowHeardAboutUs.WHATSAPP.name());
+    SURVEY_TYPE_MAPPING.put("YouTube", HowHeardAboutUs.YOUTUBE.name());
+    SURVEY_TYPE_MAPPING.put("Friend or colleague referral", HowHeardAboutUs.FRIEND_COLLEAGUE_REFERRAL.name());
+    SURVEY_TYPE_MAPPING.put("From a friend", HowHeardAboutUs.FRIEND_COLLEAGUE_REFERRAL.name());
+    SURVEY_TYPE_MAPPING.put("University or school referral", HowHeardAboutUs.UNIVERSITY_SCHOOL_REFERRAL.name());
+    SURVEY_TYPE_MAPPING.put("Employer referral", HowHeardAboutUs.EMPLOYER_REFERRAL.name());
+    SURVEY_TYPE_MAPPING.put("Event or webinar", HowHeardAboutUs.EVENT_WEBINAR.name());
+    SURVEY_TYPE_MAPPING.put("Information Session", HowHeardAboutUs.INFORMATION_SESSION.name());
+    SURVEY_TYPE_MAPPING.put("Community centre posting - flyers", HowHeardAboutUs.COMMUNITY_CENTRE_POSTING_FLYERS.name());
+    SURVEY_TYPE_MAPPING.put("Outreach worker", HowHeardAboutUs.OUTREACH_WORKER.name());
+    SURVEY_TYPE_MAPPING.put("NGO", HowHeardAboutUs.NGO.name());
+    SURVEY_TYPE_MAPPING.put("UNHCR", HowHeardAboutUs.UNHCR.name());
+    SURVEY_TYPE_MAPPING.put("US-Afghan", HowHeardAboutUs.US_AFGHAN.name());
+    SURVEY_TYPE_MAPPING.put("ULYP", HowHeardAboutUs.ULYP.name());
+    SURVEY_TYPE_MAPPING.put("Techfugees", HowHeardAboutUs.TECHFUGEES.name());
+    SURVEY_TYPE_MAPPING.put("Al Ghurair Foundation", HowHeardAboutUs.AL_GHURAIR_FOUNDATION.name());
+    SURVEY_TYPE_MAPPING.put("Other", HowHeardAboutUs.OTHER.name());
+    String mappedValue = SURVEY_TYPE_MAPPING.get(surveyTypeName);
+    try {
+      return mappedValue;
+    } catch (IllegalArgumentException e) {
+      return "OTHER";
+    }
   }
 }


### PR DESCRIPTION
This PR fixes an api bug that was preventing all candidate lookups due to an incorrect mapping from TC candidate entities to their Mongo document equivalents.

Once merged and deployed -- run a full anonymisation :

- [ ] On Staging
- [ ] On Production