### PR TITLE
2877 valid api keys intermittently rejected as unknown api key

### DIFF
--- a/src/main/java/org/tctalent/anonymization/service/TalentCatalogServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/TalentCatalogServiceImpl.java
@@ -194,6 +194,10 @@ public class TalentCatalogServiceImpl implements TalentCatalogService {
           login();
           return doFindPartnerByPublicApiKey(apiKey);
         }
+        if (e.getStatusCode().isSameCodeAs(HttpStatus.NOT_FOUND)) {
+          // no partner found for this API key
+          return null;
+        }
         throw e;
       }
     }


### PR DESCRIPTION
This PR refactors the logic for fetching a partner by public API key in TalentCatalogServiceImpl.java to improve error handling and code safety. 

The main changes include - 

- extracting the API call into a helper method
- using safer URI parameterisation
- handling token expiration and missing partners more gracefully 
    - now checks for token expiration (`UNAUTHORIZED` errors), attempts to re-login, and retries the API call once if necessary
    - also handles `NOT_FOUND` errors by returning `null` when no partner is found for the provided API key.
