### PR TITLE
3075 post service deployment testing and extra params check

### DIFF
--- a/infra/terraform/acm.tf
+++ b/infra/terraform/acm.tf
@@ -13,6 +13,23 @@ resource "aws_acm_certificate" "this" {
   tags = local.tags
 }
 
+# DNS validation records for ACM certificate
+resource "aws_route53_record" "certificate_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id = aws_route53_zone.this.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [each.value.record]
+}
+
 # Waits for DNS validation to complete before the certificate is usable
 resource "aws_acm_certificate_validation" "this" {
   certificate_arn         = aws_acm_certificate.this.arn

--- a/infra/terraform/database.tf
+++ b/infra/terraform/database.tf
@@ -17,9 +17,10 @@ module "db" {
 
   publicly_accessible = true
 
-  master_username = var.db_user_name
-  master_password = var.database_password != "" ? var.database_password : null
-  database_name   = var.db_name
+  master_username             = var.db_user_name
+  master_password             = var.database_password != "" ? var.database_password : null
+  manage_master_user_password = var.database_password != "" ? false : true
+  database_name               = var.db_name
 
   vpc_id               = module.vpc.vpc_id
   db_subnet_group_name = module.vpc.database_subnet_group

--- a/infra/terraform/dns.tf
+++ b/infra/terraform/dns.tf
@@ -28,20 +28,3 @@ resource "aws_route53_record" "www" {
   ttl     = "600"
   records = [var.site_domain]
 }
-
-# DNS validation records for ACM certificate
-resource "aws_route53_record" "certificate_validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      type   = dvo.resource_record_type
-      record = dvo.resource_record_value
-    }
-  }
-
-  zone_id = aws_route53_zone.this.zone_id
-  name    = each.value.name
-  type    = each.value.type
-  ttl     = 60
-  records = [each.value.record]
-}

--- a/infra/terraform/dns.tf
+++ b/infra/terraform/dns.tf
@@ -8,6 +8,27 @@ resource "aws_route53_zone" "this" {
   tags = local.tags
 }
 
+# A record pointing the domain to the ALB
+resource "aws_route53_record" "ipv4" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = var.site_domain
+  type    = "A"
+
+  alias {
+    name                   = module.alb.dns_name
+    zone_id                = module.alb.zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = "www"
+  type    = "CNAME"
+  ttl     = "600"
+  records = [var.site_domain]
+}
+
 # DNS validation records for ACM certificate
 resource "aws_route53_record" "certificate_validation" {
   for_each = {

--- a/infra/terraform/network.tf
+++ b/infra/terraform/network.tf
@@ -19,7 +19,7 @@ module "vpc" {
 
   create_database_subnet_group           = true
   create_database_subnet_route_table     = true
-  create_database_internet_gateway_route = true
+  create_database_internet_gateway_route = false
 
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/infra/terraform/tc-api-opc-prod/main.tf
+++ b/infra/terraform/tc-api-opc-prod/main.tf
@@ -41,6 +41,7 @@ module "tc-opc-prod" {
   project_name        = "tc-api"
   project_description = "OPC production setup for tc-api"
   environment         = "opc-prod"
+  aws_region          = "eu-west-2"
   image_tag           = "tc-api-prod"
   fargate_cpu         = 512
   fargate_memory      = 2048

--- a/infra/terraform/tc-api-opc-prod/main.tf
+++ b/infra/terraform/tc-api-opc-prod/main.tf
@@ -34,7 +34,7 @@ provider "aws" {
 }
 
 # tc-api infrastructure for OPC AWS production account
-module tc-opc-prod {
+module "tc-opc-prod" {
   source = "./.."
 
   # Provided as Terraform inputs

--- a/infra/terraform/tc-api-opc-test/main.tf
+++ b/infra/terraform/tc-api-opc-test/main.tf
@@ -34,7 +34,7 @@ provider "aws" {
 }
 
 # tc-api infrastructure for OPC AWS staging account
-module tc-opc-test {
+module "tc-opc-test" {
   source = "./.."
 
   # Provided as Terraform inputs

--- a/infra/terraform/tc-api-opc-test/main.tf
+++ b/infra/terraform/tc-api-opc-test/main.tf
@@ -41,6 +41,7 @@ module "tc-opc-test" {
   project_name        = "tc-api"
   project_description = "OPC staging setup for tc-api"
   environment         = "opc-staging"
+  aws_region          = "eu-west-2"
   image_tag           = "tc-api-staging"
   fargate_cpu         = 512
   fargate_memory      = 2048


### PR DESCRIPTION
This PR -

- Moves DNS validation records for ACM certificate to acm.tf
- Adds A record pointing the domain to the ALB
- Configures a CNAME record
- Hardens public DB access through internet gateway (a separate ticket has been opened to setup a team VPN for DB access)
- Does not use RDS password if a master password is provided in tfvars

Note: The DNS/ACM config may change in light of CloudFront - however, prior to then, these updates needs to be merged because they are reflective of the current Terraform baseline.

Note also that there are subtle terraform differences between the 3 TC services. 
tc-terraform should be updated and all 3 services should use that as a common terraform standard. (A separate issue has been opened for this)