### PR TITLE
3160 migrate staging services to opc accounts

### DIFF
--- a/infra/terraform/acm.tf
+++ b/infra/terraform/acm.tf
@@ -13,6 +13,23 @@ resource "aws_acm_certificate" "this" {
   tags = local.tags
 }
 
+# DNS validation records for ACM certificate
+resource "aws_route53_record" "certificate_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id = aws_route53_zone.this.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [each.value.record]
+}
+
 # Waits for DNS validation to complete before the certificate is usable
 resource "aws_acm_certificate_validation" "this" {
   certificate_arn         = aws_acm_certificate.this.arn

--- a/infra/terraform/database.tf
+++ b/infra/terraform/database.tf
@@ -17,9 +17,10 @@ module "db" {
 
   publicly_accessible = true
 
-  master_username = var.db_user_name
-  master_password = var.database_password != "" ? var.database_password : null
-  database_name   = var.db_name
+  master_username             = var.db_user_name
+  master_password             = var.database_password != "" ? var.database_password : null
+  manage_master_user_password = var.database_password != "" ? false : true
+  database_name               = var.db_name
 
   vpc_id               = module.vpc.vpc_id
   db_subnet_group_name = module.vpc.database_subnet_group

--- a/infra/terraform/dns.tf
+++ b/infra/terraform/dns.tf
@@ -28,20 +28,3 @@ resource "aws_route53_record" "www" {
   ttl     = "600"
   records = [var.site_domain]
 }
-
-# DNS validation records for ACM certificate
-resource "aws_route53_record" "certificate_validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      type   = dvo.resource_record_type
-      record = dvo.resource_record_value
-    }
-  }
-
-  zone_id = aws_route53_zone.this.zone_id
-  name    = each.value.name
-  type    = each.value.type
-  ttl     = 60
-  records = [each.value.record]
-}

--- a/infra/terraform/dns.tf
+++ b/infra/terraform/dns.tf
@@ -8,6 +8,27 @@ resource "aws_route53_zone" "this" {
   tags = local.tags
 }
 
+# A record pointing the domain to the ALB
+resource "aws_route53_record" "ipv4" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = var.site_domain
+  type    = "A"
+
+  alias {
+    name                   = module.alb.dns_name
+    zone_id                = module.alb.zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = "www"
+  type    = "CNAME"
+  ttl     = "600"
+  records = [var.site_domain]
+}
+
 # DNS validation records for ACM certificate
 resource "aws_route53_record" "certificate_validation" {
   for_each = {

--- a/infra/terraform/network.tf
+++ b/infra/terraform/network.tf
@@ -19,7 +19,7 @@ module "vpc" {
 
   create_database_subnet_group           = true
   create_database_subnet_route_table     = true
-  create_database_internet_gateway_route = true
+  create_database_internet_gateway_route = false
 
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/infra/terraform/tc-api-opc-prod/main.tf
+++ b/infra/terraform/tc-api-opc-prod/main.tf
@@ -41,6 +41,7 @@ module "tc-opc-prod" {
   project_name        = "tc-api"
   project_description = "OPC production setup for tc-api"
   environment         = "opc-prod"
+  aws_region          = "eu-west-2"
   image_tag           = "tc-api-prod"
   fargate_cpu         = 512
   fargate_memory      = 2048

--- a/infra/terraform/tc-api-opc-prod/main.tf
+++ b/infra/terraform/tc-api-opc-prod/main.tf
@@ -34,7 +34,7 @@ provider "aws" {
 }
 
 # tc-api infrastructure for OPC AWS production account
-module tc-opc-prod {
+module "tc-opc-prod" {
   source = "./.."
 
   # Provided as Terraform inputs

--- a/infra/terraform/tc-api-opc-test/main.tf
+++ b/infra/terraform/tc-api-opc-test/main.tf
@@ -55,7 +55,7 @@ module "tc-opc-test" {
   site_domain         = "test.api.tctalent.org"
 
   # SSM-backed (stored in SSM, injected into ECS task)
-  tc_api_url          = "https://test.plus.tctalent.org/api/admin"
+  tc_api_url          = "https://tctalent-test.org/api/admin"
   tc_search_id        = 2682
   tc_username         = "tc-api"
   tc_password         = var.tc_password

--- a/infra/terraform/tc-api-opc-test/main.tf
+++ b/infra/terraform/tc-api-opc-test/main.tf
@@ -34,7 +34,7 @@ provider "aws" {
 }
 
 # tc-api infrastructure for OPC AWS staging account
-module tc-opc-test {
+module "tc-opc-test" {
   source = "./.."
 
   # Provided as Terraform inputs

--- a/infra/terraform/tc-api-opc-test/main.tf
+++ b/infra/terraform/tc-api-opc-test/main.tf
@@ -41,6 +41,7 @@ module "tc-opc-test" {
   project_name        = "tc-api"
   project_description = "OPC staging setup for tc-api"
   environment         = "opc-staging"
+  aws_region          = "eu-west-2"
   image_tag           = "tc-api-staging"
   fargate_cpu         = 512
   fargate_memory      = 2048

--- a/infra/terraform/tc-api-opc-test/main.tf
+++ b/infra/terraform/tc-api-opc-test/main.tf
@@ -52,7 +52,7 @@ module "tc-opc-test" {
   db_instance_class   = "db.t3.medium"
   db_version          = "17.5"
   dns_namespace       = "tc-api.local"
-  site_domain         = "test.api.plus.tctalent.org"
+  site_domain         = "test.api.tctalent.org"
 
   # SSM-backed (stored in SSM, injected into ECS task)
   tc_api_url          = "https://test.plus.tctalent.org/api/admin"


### PR DESCRIPTION
This PR builds on #136

Once that is approved and merged then this PR will have only a single file change -- opc-staging/main.tf

1. the domain is updated from test.api.plus.tctalent.org to test.api.tctalent.org
2. the tc_api_irl is updated from https://test.plus.tctalent.org/api/admin to https://tctalent-test.org/api/admin

The changes have already been applied to opc-staging via terraform.

The API service has been tested and verified on OPC AWS.
 
The legacy API staging service has been switched off.