### PR TITLE
update CODEOWNERS to apply ownership to all paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-@camerojo @sadatmalik
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @camerojo @sadatmalik


### PR DESCRIPTION
This PR makes a minor update to the .github/CODEOWNERS file to ensure the code owners are specified reviewers for all paths in the repository.